### PR TITLE
Symbolic basis

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -270,6 +270,7 @@ intersphinx_mapping = {
         "https://docs.python.org/": None,
         "https://docs.scipy.org/doc/numpy/": None,
         "https://documen.tician.de/pytools": None,
+        "https://documen.tician.de/pymbolic": None,
         }
 
 autoclass_content = "class"

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -73,20 +73,20 @@ Dimension-specific functions
 
 .. currentmodule:: modepy.modes
 
-.. autofunction:: pkdo_2d(order, rs)
-.. autofunction:: grad_pkdo_2d(order, rs)
-.. autofunction:: pkdo_3d(order, rst)
-.. autofunction:: grad_pkdo_3d(order, rst)
+.. autofunction:: pkdo_2d
+.. autofunction:: grad_pkdo_2d
+.. autofunction:: pkdo_3d
+.. autofunction:: grad_pkdo_3d
 
 Monomials
 ---------
 
-.. autofunction:: monomial(order, rst)
-.. autofunction:: grad_monomial(order, rst)
+.. autofunction:: monomial
+.. autofunction:: grad_monomial
 
 Symbolic Basis Functions
 ------------------------
-.. autofunction:: symbolicize_basis(order, rst)
+.. autofunction:: symbolicize_basis
 """
 
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -101,7 +101,7 @@ def jacobi(alpha, beta, n, x):
     Jacobi weight :math:`(1-x)^\alpha(1+x)^\beta`.
 
     Observe that choosing :math:`\alpha=\beta=0` will yield the
-    `Legendre polynomials <https://en.wikipedia.org/wiki/Legendre_polynomials>`_.
+    `Legendre polynomials <https://en.wikipedia.org/wiki/Legendre_polynomials>`__.
     """
 
     out_shape = x.shape

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -56,15 +56,10 @@ Dimension-independent basis getters for simplices
     http://dx.doi.org/10.1007/BF01060030
 
 .. autofunction:: simplex_onb_with_mode_ids
-
 .. autofunction:: simplex_onb
-
 .. autofunction:: grad_simplex_onb
-
 .. autofunction:: simplex_monomial_basis_with_mode_ids
-
 .. autofunction:: simplex_monomial_basis
-
 .. autofunction:: grad_simplex_monomial_basis
 
 Dimension-independent basis getters for tensor-product bases
@@ -79,18 +74,14 @@ Dimension-specific functions
 .. currentmodule:: modepy.modes
 
 .. autofunction:: pkdo_2d(order, rs)
-
 .. autofunction:: grad_pkdo_2d(order, rs)
-
 .. autofunction:: pkdo_3d(order, rst)
-
 .. autofunction:: grad_pkdo_3d(order, rst)
 
 Monomials
 ---------
 
 .. autofunction:: monomial(order, rst)
-
 .. autofunction:: grad_monomial(order, rst)
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
 
-git+https://github.com/inducer/pymbolic.git@comparison-if-fixes#egg=pymbolic
+git+https://github.com/inducer/pymbolic.git#egg=pymbolic

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 numpy
+
+git+https://github.com/inducer/pymbolic.git@comparison-if-fixes#egg=pymbolic

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -59,10 +59,9 @@ def test_warp():
     n = 17
     from modepy.nodes import warp_factor
     from functools import partial
-    from modepy.tools import accept_scalar_or_vector
 
-    wfc = accept_scalar_or_vector(1, 1)(
-            partial(warp_factor, 17, scaled=False))
+    def wfc(x):
+        return warp_factor(n, np.array([x]), scaled=False)[0]
 
     assert abs(wfc(-1)) < 1e-12
     assert abs(wfc(1)) < 1e-12
@@ -70,7 +69,7 @@ def test_warp():
     from modepy.quadrature.jacobi_gauss import LegendreGaussQuadrature
 
     lgq = LegendreGaussQuadrature(n)
-    assert abs(lgq(wfc)) < 6e-14
+    assert abs(lgq(partial(warp_factor, n, scaled=False))) < 6e-14
 
 
 def test_tri_face_node_distribution():


### PR DESCRIPTION
- [x] Depends on https://github.com/inducer/pymbolic/pull/26
    - [x] Point `requirements.txt` back to master once that's in
- [x] Test with meshmode: https://github.com/inducer/meshmode/pull/88
- [x] Test with grudge: https://github.com/inducer/grudge/pull/33
- [x] Test with pytential: https://github.com/inducer/pytential/pull/40

@xywei This gives you a way to access symbolic expressions for basis functions, which might help with interpolation in volumential. (Probably best to add a bit of plumbing to meshmode, rather than access modepy directly.)

@alexfikl Turns out getting the basis functions to be symbolic does not require a whole new interface after all.
