### PR TITLE
Document face mass matrix functions, add nodal_quad_mass_matrix_for_face, deprecate broken use of nodal_mass_matrix_for_face, bump version

### DIFF
--- a/modepy/__init__.py
+++ b/modepy/__init__.py
@@ -54,7 +54,8 @@ from modepy.matrices import (vandermonde,
         diff_matrix_permutation,
         inverse_mass_matrix, mass_matrix,
         modal_face_mass_matrix, nodal_face_mass_matrix,
-        modal_mass_matrix_for_face, nodal_mass_matrix_for_face)
+        modal_mass_matrix_for_face, nodal_mass_matrix_for_face,
+        nodal_quad_mass_matrix_for_face)
 from modepy.quadrature import (
         Quadrature, QuadratureRuleUnavailable,
         TensorProductQuadrature, LegendreGaussTensorProductQuadrature,
@@ -106,6 +107,7 @@ __all__ = [
         "inverse_mass_matrix", "mass_matrix",
         "modal_face_mass_matrix", "nodal_face_mass_matrix",
         "modal_mass_matrix_for_face", "nodal_mass_matrix_for_face",
+        "nodal_quad_mass_matrix_for_face",
 
         "Quadrature", "QuadratureRuleUnavailable",
         "TensorProductQuadrature", "LegendreGaussTensorProductQuadrature",

--- a/modepy/matrices.py
+++ b/modepy/matrices.py
@@ -56,6 +56,7 @@ where :math:`(\phi_i)_i` is the basis of functions underlying :math:`V`.
 .. autofunction:: mass_matrix
 .. autofunction:: modal_mass_matrix_for_face
 .. autofunction:: nodal_mass_matrix_for_face
+.. autofunction:: nodal_quad_mass_matrix_for_face
 
 Differentiation is also convenient to express by using :math:`V^{-1}` to
 obtain modal values and then using a Vandermonde matrix for the derivatives
@@ -247,7 +248,17 @@ def mass_matrix(basis, nodes):
 
 def modal_mass_matrix_for_face(face: Face, face_quad: Quadrature,
         trial_functions, test_functions):
-    """
+    r"""Using the quadrature *face_quad*, provide a matrix :math:`M_f` that
+    satisfies:
+
+    .. math::
+
+        \displaystyle {(M_f)}_{ij} \approx \int_F \phi_i(r) \psi_j(r) dr,
+
+    where :math:`\phi_i` are the (volume) Lagrange basis functions obtained from
+    *test_functions* at *volume_nodes*, and :math:`\psi_j` are the (surface)
+    *trial_functions*.
+
     .. versionadded:: 2020.3
     """
 
@@ -265,15 +276,64 @@ def modal_mass_matrix_for_face(face: Face, face_quad: Quadrature,
 
 def nodal_mass_matrix_for_face(face: Face, face_quad: Quadrature,
         trial_functions, test_functions, volume_nodes, face_nodes):
-    """
+    r"""Using the quadrature *face_quad*, provide a matrix :math:`M_f` that
+    satisfies:
+
+    .. math::
+
+        \displaystyle {(M_f)}_{ij} \approx \int_F \phi_i(r) \psi_j(r) dr,
+
+    where :math:`\phi_i` are the (volume) Lagrange basis functions obtained from
+    *test_functions* at *volume_nodes*, and :math:`\psi_j` are the (surface)
+    Lagrange basis functions obtained from *trial_functions* at *face_nodes*.
+
     .. versionadded :: 2020.3
     """
     face_vdm = vandermonde(trial_functions, face_nodes)
     vol_vdm = vandermonde(test_functions, volume_nodes)
 
+    nface_nodes, nface_funcs = face_vdm.shape
+    if nface_nodes != nface_funcs:
+        from warnings import warn
+        warn("nodal_mass_matrix_for_face received a different number of facial "
+                "nodes than facial trial_functions. This used to be accepted, "
+                "but it is not well-defined. This usage will be rejected starting "
+                "in 2022.x.", DeprecationWarning, stacklevel=2)
+
+        face_vdm_inv = la.pinv(face_vdm)
+    else:
+        face_vdm_inv = la.inv(face_vdm)
+
     modal_fmm = modal_mass_matrix_for_face(
             face, face_quad, trial_functions, test_functions)
-    return la.inv(vol_vdm.T).dot(modal_fmm).dot(la.pinv(face_vdm))
+    return la.inv(vol_vdm.T).dot(modal_fmm).dot(face_vdm_inv)
+
+
+def nodal_quad_mass_matrix_for_face(face: Face, face_quad: Quadrature,
+        test_functions, volume_nodes):
+    r"""Using the quadrature *face_quad*, provide a matrix :math:`M_f` that
+    satisfies:
+
+    .. math::
+
+        \displaystyle (M_f \boldsymbol u)_i = \sum_j w_j \phi_i(r_j) u_j,
+
+    where :math:`\phi_i` are the (volume) Lagrange basis functions obtained from
+    *test_functions* at *volume_nodes*, and :math:`w_i` and :math:`r_i` are the
+    weights and nodes from *face_quad*.
+
+    .. versionadded :: 2021.2
+    """
+    vol_vdm = vandermonde(test_functions, volume_nodes)
+
+    mapped_nodes = face.map_to_volume(face_quad.nodes)
+
+    vol_modal_mass_matrix = np.empty((len(test_functions), len(face_quad.weights)))
+
+    for i, test_f in enumerate(test_functions):
+        vol_modal_mass_matrix[i] = test_f(mapped_nodes) * face_quad.weights
+
+    return la.inv(vol_vdm.T) @ vol_modal_mass_matrix
 
 
 # {{{ deprecated junk

--- a/modepy/version.py
+++ b/modepy/version.py
@@ -1,2 +1,2 @@
-VERSION = (2021, 1)
+VERSION = (2021, 2)
 VERSION_TEXT = ".".join(str(i) for i in VERSION)


### PR DESCRIPTION
`nodal_mass_matrix_for_face` permitted a "pseudo-overintegrated" usage, where it would use pseudoinverses to find coefficients and then try to piggyback off of `modal_face_mass_matrix`. For computing face mass matrices in vanilla nodal DG (where the pseudoinverse is the actual inverse), that is OK. But for overintegrated use, this is complete nonsense (and deprecated by this PR). This introduces a new `nodal_quad_mass_matrix_for_face` that does less, but correctly.

Prompted by @thomasgibson's prodding in https://github.com/inducer/grudge/pull/62#discussion_r611879139.

- [x] :warning: Wait for #29.

cc @lukeolson