### PR TITLE
Remove UNIT_VERTICES

### DIFF
--- a/modepy/modal_decay.py
+++ b/modepy/modal_decay.py
@@ -78,7 +78,7 @@ def simplex_interp_error_coefficient_estimator_matrix(
 def make_mode_number_vector(mode_order_tuples, ignored_modes):
     node_cnt = len(mode_order_tuples)
 
-    mode_number_vector = np.zeros(node_cnt-ignored_modes, dtype=np.int)
+    mode_number_vector = np.zeros(node_cnt-ignored_modes, dtype=int)
     for i, mid in enumerate(mode_order_tuples):
         if i < ignored_modes:
             continue

--- a/modepy/modal_decay.py
+++ b/modepy/modal_decay.py
@@ -78,7 +78,7 @@ def simplex_interp_error_coefficient_estimator_matrix(
 def make_mode_number_vector(mode_order_tuples, ignored_modes):
     node_cnt = len(mode_order_tuples)
 
-    mode_number_vector = np.zeros(node_cnt-ignored_modes, dtype=int)
+    mode_number_vector = np.zeros(node_cnt-ignored_modes, dtype=np.int32)
     for i, mid in enumerate(mode_order_tuples):
         if i < ignored_modes:
             continue

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -198,17 +198,6 @@ def unit_vertices(dim):
     return shp.unit_vertices_for_shape(shp.Simplex(dim)).T
 
 
-# FIXME This should go away, but as of 2020-12-02, it is still being used by
-# meshmode.  (The use is being removed in
-# https://github.com/inducer/meshmode/pull/70, around the same time.)
-UNIT_VERTICES = {
-        0: unit_vertices(0),
-        1: unit_vertices(1),
-        2: unit_vertices(2),
-        3: unit_vertices(3),
-        }
-
-
 def barycentric_to_unit(bary):
     """
     :arg bary: shaped ``(dims+1, npoints)``


### PR DESCRIPTION
With https://github.com/inducer/grudge/pull/62 merged, I believe it is now safe to remove `UNIT_VERTICES`. Also makes a minor change to an unnecessary alias :)