### PR TITLE
Generalize tensor product spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ modepy: Basis Functions and Node Sets for Interpolation
     :alt: Python Package Index Release Page
     :target: https://pypi.org/project/modepy/
 
-modepy helps you create well-behaved high-order
-discretizations on simplices (i.e. triangles and tetrahedra).
-These are a key building block for high-order unstructured
-discretizations, as often used in a finite element context.
-It closely follows the approach taken in the book
+``modepy`` helps you create well-behaved high-order discretizations on
+simplices (i.e. segments, triangles and tetrahedra) and tensor products of
+simplices (i.e. squares, cubes, prisms, etc.). These are a key building block
+for high-order unstructured discretizations, as often used in a finite
+element context. It closely follows the approach taken in the book
 
   Hesthaven, Jan S., and Tim Warburton. "Nodal Discontinuous Galerkin Methods:
   Algorithms, Analysis, and Applications". 1st ed. Springer, 2007.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,11 +3,11 @@ Welcome to modepy's documentation!
 
 .. module:: modepy
 
-:mod:`modepy` helps you create well-behaved high-order
-discretizations on simplices (i.e. triangles and tetrahedra).
-These are a key building block for high-order unstructured
-discretizations, as often used in a finite element context.
-It closely follows the approach taken in the book
+:mod:`modepy` helps you create well-behaved high-order discretizations on
+simplices (i.e. triangles and tetrahedra) and tensor products of simplices
+(i.e. squares, cubes, prisms, etc.). These are a key building block for
+high-order unstructured discretizations, as often used in a finite element
+context. It closely follows the approach taken in the book
 
   Hesthaven, Jan S., and Tim Warburton. "Nodal Discontinuous Galerkin Methods:
   Algorithms, Analysis, and Applications". 1st ed. Springer, 2007.

--- a/modepy/__init__.py
+++ b/modepy/__init__.py
@@ -29,7 +29,7 @@ from modepy.shapes import (
         submesh_for_shape,
         )
 from modepy.spaces import (
-        FunctionSpace, PN, QN, space_for_shape)
+        FunctionSpace, TensorProductSpace, PN, QN, space_for_shape)
 from modepy.modes import (
         jacobi, grad_jacobi,
         simplex_onb, grad_simplex_onb, simplex_onb_with_mode_ids,
@@ -83,7 +83,7 @@ __all__ = [
         "face_normal", "unit_vertices_for_shape", "faces_for_shape",
         "submesh_for_shape",
 
-        "FunctionSpace", "PN", "QN", "space_for_shape",
+        "FunctionSpace", "TensorProductSpace", "PN", "QN", "space_for_shape",
 
         "jacobi", "grad_jacobi",
         "simplex_onb", "grad_simplex_onb", "simplex_onb_with_mode_ids",

--- a/modepy/__init__.py
+++ b/modepy/__init__.py
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 
 from modepy.shapes import (
-        Shape, Face, Simplex, Hypercube,
+        Shape, Face, Simplex, Hypercube, TensorProductShape,
 
         face_normal, unit_vertices_for_shape, faces_for_shape,
         submesh_for_shape,
@@ -79,7 +79,7 @@ GaussLegendreQuadrature = LegendreGaussQuadrature
 __all__ = [
         "__version__",
 
-        "Shape", "Face", "Simplex", "Hypercube",
+        "Shape", "Face", "Simplex", "Hypercube", "TensorProductShape",
         "face_normal", "unit_vertices_for_shape", "faces_for_shape",
         "submesh_for_shape",
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -847,8 +847,8 @@ class Basis:
 
     def orthonormality_weight(self) -> float:
         """
-        Can raise :exc:`BasisNotOrthonormal` if the basis does not have
-        a weight.
+        :raises: :exc:`BasisNotOrthonormal` if the basis does not have
+            a weight.
         """
         raise NotImplementedError
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -721,7 +721,7 @@ class _TensorProductGradientBasisFunction:
         A :class:`tuple` of :class:`tuple`\ s of callables ``df[i][j]`` that
         evaluate the derivatives of the tensor product. Each ``df[i]`` tuple
         is equivalent to a :class:`_TensorProductBasisFunction` and is used
-        to evaluate the derivative of a single basis functions of the tensor
+        to evaluate the derivatives of a single basis function of the tensor
         product. To be specific, a basis function in the tensor product is
         given by
 
@@ -742,10 +742,12 @@ class _TensorProductGradientBasisFunction:
                 \times \cdots \times
                 f_n.
 
-        In our notation, ``df[i][k]`` represents a term in the product above.
-        When evaluating :math:`f_i`, the callable just returns the function
-        values, but when evaluating :math:`\partial_k f_i` it should return
-        all the derivatives with respect to :math:`k \in [d_i, d_{i + 1}]`.
+        In our notation, ``df[i]`` gives all the derivatives of :math:`f`
+        with respect to :math:`k \in [d_i, d_{i + 1})`. When evaluating
+        ``df[i][j]`` can be a function :math:`f_i`, for which the callable
+        just returns the function values, or :math:`\partial_k f_i`, for
+        which it returns all the derivatives with respect to
+        :math:`k \in [d_i, d_{i + 1}]`.
 
     .. attribute:: dims_per_function
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1123,11 +1123,12 @@ class TensorProductBasis(Basis):
 
 
 def _get_orth_weight(bases: Sequence[Basis]) -> Optional[float]:
-    orth_weight = 1
+    orth_weight: Optional[float] = 1.0
     for b in bases:
-        if b.is_orthonormal:
+        try:
+            assert orth_weight is not None
             orth_weight *= b.orthonormality_weight()
-        else:
+        except BasisNotOrthonormal:
             orth_weight = None
             break
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -21,10 +21,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from abc import ABC, abstractproperty, abstractmethod
 from warnings import warn
 from math import sqrt
 from functools import singledispatch, partial
-from typing import Callable, Optional, Sequence, TypeVar, Tuple, Union, TYPE_CHECKING
+from typing import (Callable, Optional, Sequence, TypeVar, Tuple, Union,
+        Hashable, TYPE_CHECKING)
 
 import numpy as np
 
@@ -853,7 +855,7 @@ class BasisNotOrthonormal(Exception):
     pass
 
 
-class Basis:
+class Basis(ABC):
     """
     .. automethod:: orthonormality_weight
     .. autoattribute:: mode_ids
@@ -861,38 +863,37 @@ class Basis:
     .. autoattribute:: gradients
     """
 
+    @abstractmethod
     def orthonormality_weight(self) -> float:
         """
         :raises: :exc:`BasisNotOrthonormal` if the basis does not have
             a weight, i.e. it is not orthogonal.
         """
-        raise NotImplementedError
 
-    @property
-    def mode_ids(self):
+    @abstractproperty
+    def mode_ids(self) -> Tuple[Hashable, ...]:
         """A tuple of of mode (basis function) identifiers, one for
         each basis function. Mode identifiers should generally be viewed
         as opaque. They are hashable. For some bases, they are tuples of
         length matching the number of dimensions and indicating the order
         along each reference axis.
         """
-        raise NotImplementedError
 
-    @property
-    def functions(self):
+    @abstractproperty
+    def functions(self) -> Tuple[Callable[[np.ndarray], np.ndarray], ...]:
         """A tuple of (callable) basis functions of length matching
         :attr:`mode_ids`.  Each function takes a vector of :math:`(r, s, t)`
         reference coordinates (depending on dimension) as input.
         """
-        raise NotImplementedError
 
-    @property
-    def gradients(self):
-        """A tuple of basis functions of length matching :attr:`mode_ids`.
-        Each function takes a vector of :math:`(r, s, t)` reference coordinates
-        (depending on dimension) as input.
+    @abstractproperty
+    def gradients(
+            self) -> Tuple[Callable[[np.ndarray], Tuple[np.ndarray, ...]], ...]:
+        """A tuple of (callable) basis functions of length matching
+        :attr:`mode_ids`.  Each function takes a vector of :math:`(r, s, t)`
+        reference coordinates (depending on dimension) as input.
+        Each function returns a tuple of derivatives, one per reference axis.
         """
-        raise NotImplementedError
 
 # }}}
 
@@ -983,7 +984,7 @@ class _SimplexONB(_SimplexBasis):
 
 
 class _SimplexMonomialBasis(_SimplexBasis):
-    def orthonormality_weight(self):
+    def orthonormality_weight(self) -> float:
         raise BasisNotOrthonormal
 
     @property

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -713,9 +713,9 @@ class _TensorProductGradientBasisFunction:
 
         result = [1] * self.ndims
         d = 0
-        for i, derivative in zip(self.dims_per_function, self.derivatives):
+        for nfunc_dims, derivative in zip(self.dims_per_function, self.derivatives):
             f = 0
-            for j, function in zip(self.dims_per_function, derivative):
+            for iaxis_loc, df_daxis_loc in zip(self.dims_per_function, derivative):
                 components = function(x[f:f + j])
                 if not isinstance(components, tuple):
                     # NOTE: just a function evaluation here, so we distribute
@@ -1103,7 +1103,7 @@ class TensorProductBasis(Basis):
                     [func[is_deriv][ibasis][mid_i]
                         for ibasis, (is_deriv, mid_i) in
                         enumerate(zip(iderivative, mid))]
-                    for iderivative in wandering_element(self._nbases)
+                    for deriv_indicator_vec in wandering_element(self._nbases)
                     ],
                     dims_per_function=self._dims_per_basis)
                 for mid in self.mode_ids)

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -715,18 +715,18 @@ class _TensorProductGradientBasisFunction:
         d = 0
         for nfunc_dims, derivative in zip(self.dims_per_function, self.derivatives):
             f = 0
-            for iaxis_loc, df_daxis_loc in zip(self.dims_per_function, derivative):
-                components = function(x[f:f + j])
+            for iaxis, df_daxis_func in zip(self.dims_per_function, derivative):
+                components = df_daxis_func(x[f:f + iaxis])
                 if not isinstance(components, tuple):
                     # NOTE: just a function evaluation here, so we distribute
                     # it to all the components of the derivatives
-                    components = (components,) * i
+                    components = (components,) * nfunc_dims
 
                 for n, r in enumerate(components):
                     result[d + n] *= r
 
-                f += j
-            d += i
+                f += iaxis
+            d += nfunc_dims
 
         return tuple(result)
 
@@ -1102,7 +1102,7 @@ class TensorProductBasis(Basis):
                 _TensorProductGradientBasisFunction(mid, [
                     [func[is_deriv][ibasis][mid_i]
                         for ibasis, (is_deriv, mid_i) in
-                        enumerate(zip(iderivative, mid))]
+                        enumerate(zip(deriv_indicator_vec, mid))]
                     for deriv_indicator_vec in wandering_element(self._nbases)
                     ],
                     dims_per_function=self._dims_per_basis)

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1166,7 +1166,7 @@ def _orthonormal_basis_for_tp(space: TensorProductSpace, shape: Hypercube):
             [b.functions for b in reversed(bases)],
             [b.gradients for b in reversed(bases)],
             orth_weight=_get_orth_weight(bases),
-            dims_per_basis=tuple([b.spatial_dim for b in space.bases]))
+            dims_per_basis=tuple([b.spatial_dim for b in reversed(space.bases)]))
 
 
 @basis_for_space.register(TensorProductSpace)
@@ -1180,7 +1180,7 @@ def _basis_for_tp(space: TensorProductSpace, shape: Hypercube):
             [b.functions for b in reversed(bases)],
             [b.gradients for b in reversed(bases)],
             orth_weight=_get_orth_weight(bases),
-            dims_per_basis=tuple([b.spatial_dim for b in space.bases]))
+            dims_per_basis=tuple([b.spatial_dim for b in reversed(space.bases)]))
 
 
 @monomial_basis_for_space.register(TensorProductSpace)
@@ -1194,7 +1194,7 @@ def _monomial_basis_for_tp(space: TensorProductSpace, shape: Hypercube):
             [b.functions for b in reversed(bases)],
             [b.gradients for b in reversed(bases)],
             orth_weight=None,
-            dims_per_basis=tuple([b.spatial_dim for b in space.bases]))
+            dims_per_basis=tuple([b.spatial_dim for b in reversed(space.bases)]))
 
 # }}}
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -491,6 +491,7 @@ def _node_tuples_for_tp(space: TensorProductSpace):
     tuples_for_space = [node_tuples_for_space(s) for s in space.bases]
 
     n = len(tuples_for_space)
+
     def concat(tuples):
         return sum(tuples, ())
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -490,8 +490,9 @@ def _node_tuples_for_tp(space: TensorProductSpace):
     from pytools import generate_nonnegative_integer_tuples_below as gnitb
     tuples_for_space = [node_tuples_for_space(s) for s in space.bases]
 
+    n = len(tuples_for_space)
     r = tuple([
-        sum((tuples_for_space[i][j] for i, j in enumerate(tp[::-1])), ())
+        sum((tuples_for_space[n - i - 1][j] for i, j in enumerate(tp[::-1])), ())
         for tp in gnitb([len(tp) for tp in tuples_for_space])
         ])
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -489,14 +489,13 @@ def _random_nodes_for_simplex(shape: Simplex, nnodes: int, rng=None):
 def _node_tuples_for_tp(space: TensorProductSpace):
     from pytools import generate_nonnegative_integer_tuples_below as gnitb
     tuples_for_space = [node_tuples_for_space(s) for s in space.bases]
-    tensor_product_tuples = tuple([
-        tp[::-1] for tp in gnitb([len(tp) for tp in tuples_for_space])
+
+    r = tuple([
+        sum((tuples_for_space[i][j] for i, j in enumerate(tp[::-1])), ())
+        for tp in gnitb([len(tp) for tp in tuples_for_space])
         ])
 
-    return tuple([
-        sum([tuples_for_space[i] for i in tp], ())
-        for tp in tensor_product_tuples
-        ])
+    return r
 
 
 @equispaced_nodes_for_space.register(TensorProductSpace)

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -62,7 +62,7 @@ import numpy.linalg as la
 from functools import singledispatch, partial
 
 from modepy.shapes import (
-        Shape, TensorProductShape, Simplex, Hypercube,
+        Shape, TensorProductShape, Simplex,
         unit_vertices_for_shape)
 from modepy.spaces import FunctionSpace, TensorProductSpace, PN, QN  # noqa: F401
 
@@ -541,23 +541,10 @@ def _random_nodes_for_tp(shape: TensorProductShape, nnodes: int, rng=None):
     if rng is None:
         rng = np.random.default_rng()
 
-    # FIXME: this may not be exactly uniform per dimension; any better way?
-    nnodes_per_dim = int(nnodes**(1/shape.dim)) + 1
-    nnodes_per_shape = [nnodes_per_dim**s.dim for s in shape.bases[:-1]]
-    nnodes_per_shape += [nnodes - sum(nnodes_per_shape)]
-
-    return tensor_product_nodes([
-        random_nodes_for_shape(s, nnodes, rng=rng)
-        for s, nnodes in zip(shape.bases, nnodes_per_shape)
+    return np.stack([
+        np.squeeze(random_nodes_for_shape(s, nnodes, rng=rng))
+        for s in shape.bases
         ])
-
-
-@random_nodes_for_shape.register(Hypercube)
-def _random_nodes_for_hypercube(shape: Hypercube, nnodes: int, rng=None):
-    if rng is None:
-        rng = np.random.default_rng()
-
-    return rng.uniform(-1.0, 1.0, size=(shape.dim, nnodes))
 
 # }}}
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -541,10 +541,13 @@ def _random_nodes_for_tp(shape: TensorProductShape, nnodes: int, rng=None):
     if rng is None:
         rng = np.random.default_rng()
 
-    return np.stack([
-        np.squeeze(random_nodes_for_shape(s, nnodes, rng=rng))
-        for s in shape.bases
-        ])
+    d = 0
+    nodes = np.empty((shape.dim, nnodes))
+    for s in shape.bases:
+        nodes[d:d + s.dim, :] = random_nodes_for_shape(s, nnodes, rng=rng)
+        d += s.dim
+
+    return nodes
 
 # }}}
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -532,8 +532,14 @@ def _random_nodes_for_hypercube(shape: Hypercube, nnodes: int, rng=None):
 @node_tuples_for_space.register(TensorProductSpace)
 def _node_tuples_for_tp(space: TensorProductSpace):
     from pytools import generate_nonnegative_integer_tuples_below as gnitb
+    tuples_for_space = [node_tuples_for_space(s) for s in space.bases]
+    tensor_product_tuples = tuple([
+        tp[::-1] for tp in gnitb([len(tp) for tp in tuples_for_space])
+        ])
+
     return tuple([
-        tp[::-1] for tp in gnitb([o + 1 for o in space.order])
+        sum([tuples_for_space[i] for i in tp], ())
+        for tp in tensor_product_tuples
         ])
 
 
@@ -545,8 +551,9 @@ def _equispaced_nodes_for_tp(space: TensorProductSpace, shape: Hypercube):
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
+    shapes = [type(shape)(b.spatial_dim) for b in space.bases]
     return tensor_product_nodes([
-        equispaced_nodes_for_space(b, shape) for b in space.bases
+        equispaced_nodes_for_space(b, s) for b, s in zip(space.bases, shapes)
         ])
 
 
@@ -558,8 +565,9 @@ def _edge_clustered_nodes_for_tp(space: TensorProductSpace, shape: Hypercube):
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
+    shapes = [type(shape)(b.spatial_dim) for b in space.bases]
     return tensor_product_nodes([
-        edge_clustered_nodes_for_space(b, shape) for b in space.bases
+        edge_clustered_nodes_for_space(b, s) for b, s in zip(space.bases, shapes)
         ])
 
 # }}}

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -491,12 +491,16 @@ def _node_tuples_for_tp(space: TensorProductSpace):
     tuples_for_space = [node_tuples_for_space(s) for s in space.bases]
 
     n = len(tuples_for_space)
-    r = tuple([
-        sum((tuples_for_space[n - i - 1][j] for i, j in enumerate(tp[::-1])), ())
+    def concat(tuples):
+        return sum(tuples, ())
+
+    return tuple([
+        concat((
+            tuples_for_space[n - i - 1][j]
+            for i, j in enumerate(tp[::-1])
+            ))
         for tp in gnitb([len(tp) for tp in tuples_for_space])
         ])
-
-    return r
 
 
 @equispaced_nodes_for_space.register(TensorProductSpace)

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -221,7 +221,7 @@ def _quadrature_for_tp(space: TensorProductSpace, shape: Hypercube):
             quadrature_for_space(s, shape) for s in space.bases
             ])
 
-    assert all(quad.exact_to >= o for o in space.order)
+    assert all(quad.exact_to >= getattr(s, "order", 0) for s in space.bases)
     return quad
 
 # }}}

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -215,7 +215,7 @@ def _quadrature_for_tp(space: TensorProductSpace, shape: Hypercube):
         raise ValueError("spatial dimensions of shape and space must match")
 
     if space.spatial_dim == 0:
-        quad = ZeroDimensionalQuadrature()
+        quad: Quadrature = ZeroDimensionalQuadrature()
     else:
         quad = TensorProductQuadrature([
             quadrature_for_space(s, shape) for s in space.bases

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -33,8 +33,8 @@ THE SOFTWARE.
 from functools import singledispatch
 
 import numpy as np
-from modepy.shapes import Shape, Simplex, Hypercube
-from modepy.spaces import FunctionSpace, TensorProductSpace, PN, QN
+from modepy.shapes import Shape, Simplex, TensorProductShape
+from modepy.spaces import FunctionSpace, TensorProductSpace, PN
 
 
 class QuadratureRuleUnavailable(RuntimeError):
@@ -179,6 +179,8 @@ def _quadrature_for_pn(space: PN, shape: Simplex):
     import modepy as mp
     if space.spatial_dim == 0:
         quad: Quadrature = ZeroDimensionalQuadrature()
+    elif space.spatial_dim == 1:
+        quad = mp.LegendreGaussQuadrature(space.order, force_dim_axis=True)
     else:
         try:
             quad = mp.XiaoGimbutasSimplexQuadrature(space.order, space.spatial_dim)
@@ -190,25 +192,9 @@ def _quadrature_for_pn(space: PN, shape: Simplex):
     return quad
 
 
-@quadrature_for_space.register(QN)
-def _quadrature_for_qn(space: QN, shape: Hypercube):
-    if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name__))
-    if space.spatial_dim != shape.dim:
-        raise ValueError("spatial dimensions of shape and space must match")
-
-    if space.spatial_dim == 0:
-        quad: Quadrature = ZeroDimensionalQuadrature()
-    else:
-        quad = LegendreGaussTensorProductQuadrature(space.order, space.spatial_dim)
-
-    assert quad.exact_to >= space.order
-    return quad
-
-
 @quadrature_for_space.register(TensorProductSpace)
-def _quadrature_for_tp(space: TensorProductSpace, shape: Hypercube):
-    if not isinstance(shape, Hypercube):
+def _quadrature_for_tp(space: TensorProductSpace, shape: TensorProductShape):
+    if not isinstance(shape, TensorProductShape):
         raise NotImplementedError((type(space).__name__, type(shape).__name))
 
     if space.spatial_dim != shape.dim:
@@ -218,7 +204,8 @@ def _quadrature_for_tp(space: TensorProductSpace, shape: Hypercube):
         quad: Quadrature = ZeroDimensionalQuadrature()
     else:
         quad = TensorProductQuadrature([
-            quadrature_for_space(s, shape) for s in space.bases
+            quadrature_for_space(sp, shp)
+            for sp, shp in zip(space.bases, shape.bases)
             ])
 
     assert all(quad.exact_to >= getattr(s, "order", 0) for s in space.bases)

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -168,6 +168,11 @@ The order of the vertices in the hypercubes follows binary counting
 in ``tsr`` (i.e. in reverse axis order).
 For example, in 3D, ``A, B, C, D, ...`` is ``000, 001, 010, 011, ...``.
 
+Tensor Product Shapes
+---------------------
+
+.. autoclass:: TensorProductShape
+
 Submeshes
 ---------
 .. autofunction:: submesh_for_shape
@@ -575,6 +580,12 @@ def _submesh_for_hypercube(shape: Hypercube, node_tuples):
 
 @dataclass(frozen=True, init=False)
 class TensorProductShape(Shape):
+    """
+    ... attribute:: bases
+
+        A :class:`tuple` of base shapes that form the tensor product.
+    """
+
     def __init__(self, bases: Tuple[Shape]):
         self.bases = bases
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -544,7 +544,7 @@ def _submesh_for_simplex(shape: Simplex, node_tuples):
 
 
 @submesh_for_shape.register(Hypercube)
-def _submes_for_hypercube(shape: Hypercube, node_tuples):
+def _submesh_for_hypercube(shape: Hypercube, node_tuples):
     from pytools import single_valued, add_tuples
     dims = single_valued(len(nt) for nt in node_tuples)
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -206,7 +206,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from typing import Callable, Sequence, Tuple, Dict
+from typing import Any, Callable, Sequence, Tuple, Dict
 
 from functools import singledispatch, partial
 from dataclasses import dataclass
@@ -222,6 +222,14 @@ class Shape:
     .. attribute :: nvertices
     """
     dim: int
+
+    @property
+    def nvertices(self):
+        raise NotImplementedError
+
+    @property
+    def nfaces(self):
+        raise NotImplementedError
 
 
 @singledispatch
@@ -314,7 +322,8 @@ class TensorProductShape(Shape):
 
     bases: Tuple[Shape, ...]
 
-    def __new__(cls, bases: Tuple[Shape, ...]) -> "Shape":
+    # NOTE: https://github.com/python/mypy/issues/1020
+    def __new__(cls, bases: Tuple[Shape, ...]) -> Any:
         if len(bases) == 1:
             return bases[0]
         else:
@@ -435,7 +444,8 @@ def _faces_for_simplex(shape: Simplex):
 
 @dataclass(frozen=True)
 class Hypercube(TensorProductShape):
-    def __new__(cls, dim: int) -> Shape:
+    # NOTE: https://github.com/python/mypy/issues/1020
+    def __new__(cls, dim: int) -> Any:
         if dim == 1:
             return Simplex(1)
         else:
@@ -447,7 +457,8 @@ class Hypercube(TensorProductShape):
 
 @dataclass(frozen=True, init=False)
 class _HypercubeFace(Hypercube, Face):
-    def __new__(cls, dim, **kwargs) -> Shape:
+    # NOTE: https://github.com/python/mypy/issues/1020
+    def __new__(cls, dim, **kwargs) -> Any:
         if dim == 1:
             return _SimplexFace(dim=1, **kwargs)
         else:

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -307,11 +307,11 @@ def faces_for_shape(shape: Shape) -> Tuple[Face, ...]:
 @dataclass(frozen=True)
 class Simplex(Shape):
     @property
-    def nfaces(self):
+    def nfaces(self) -> int:
         return self.dim + 1
 
     @property
-    def nvertices(self):
+    def nvertices(self) -> int:
         return self.dim + 1
 
 
@@ -371,11 +371,11 @@ def _faces_for_simplex(shape: Simplex):
 @dataclass(frozen=True)
 class Hypercube(Shape):
     @property
-    def nfaces(self):
+    def nfaces(self) -> int:
         return 2 * self.dim
 
     @property
-    def nvertices(self):
+    def nvertices(self) -> int:
         return 2**self.dim
 
 
@@ -581,24 +581,24 @@ def _submesh_for_hypercube(shape: Hypercube, node_tuples):
 @dataclass(frozen=True, init=False)
 class TensorProductShape(Shape):
     """
-    ... attribute:: bases
+    .. attribute:: bases
 
         A :class:`tuple` of base shapes that form the tensor product.
     """
 
-    def __init__(self, bases: Tuple[Shape]):
+    def __init__(self, bases: Tuple[Shape, ...]) -> None:
         self.bases = bases
 
     @property
-    def dim(self):
+    def dim(self) -> int:
         return sum(s.dim for s in self.bases)
 
     @property
-    def nvertices(self):
+    def nvertices(self) -> int:
         return np.prod([s.nvertices for s in self.bases])
 
     @property
-    def nfaces(self):
+    def nfaces(self) -> int:
         # FIXME: is there a formula for this?
         raise NotImplementedError
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -375,11 +375,11 @@ def _unit_vertices_for_tp(shape: TensorProductShape):
 @dataclass(frozen=True)
 class Simplex(Shape):
     @property
-    def nfaces(self) -> int:
+    def nfaces(self):
         return self.dim + 1
 
     @property
-    def nvertices(self) -> int:
+    def nvertices(self):
         return self.dim + 1
 
 
@@ -647,5 +647,6 @@ def _submesh_for_hypercube(shape: Hypercube, node_tuples):
     return result
 
 # }}}
+
 
 # vim: foldmethod=marker

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -623,15 +623,14 @@ def _submesh_for_simplex(shape: Simplex, node_tuples):
         raise NotImplementedError("%d-dimensional sub-meshes" % dims)
 
 
-@submesh_for_shape.register(Hypercube)
-def _submesh_for_hypercube(shape: Hypercube, node_tuples):
-    from pytools import single_valued, add_tuples
-    dims = single_valued(len(nt) for nt in node_tuples)
+@submesh_for_shape.register(TensorProductShape)
+def _submesh_for_hypercube(shape: TensorProductShape, node_tuples):
+    from modepy.spaces import space_for_shape
+    space = space_for_shape(shape, order=1)
+    from modepy.nodes import node_tuples_for_space
+    vertex_node_tuples = node_tuples_for_space(space)
 
-    # NOTE: nodes use "first coordinate varies faster" (see node_tuples_for_space)
-    from pytools import generate_nonnegative_integer_tuples_below as gnitb
-    vertex_node_tuples = [nt[::-1] for nt in gnitb(2, dims)]
-
+    from pytools import add_tuples
     result = []
     node_dict = {ituple: idx for idx, ituple in enumerate(node_tuples)}
     for current in node_tuples:

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -595,8 +595,7 @@ class TensorProductShape(Shape):
 
     @property
     def nvertices(self):
-        from math import prod
-        return prod(s.nvertices for s in self.bases)
+        return np.prod([s.nvertices for s in self.bases])
 
     @property
     def nfaces(self):

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -299,6 +299,7 @@ def faces_for_shape(shape: Shape) -> Tuple[Face, ...]:
 
 # {{{ simplex
 
+@dataclass(frozen=True)
 class Simplex(Shape):
     @property
     def nfaces(self):
@@ -362,6 +363,7 @@ def _faces_for_simplex(shape: Simplex):
 
 # {{{ hypercube
 
+@dataclass(frozen=True)
 class Hypercube(Shape):
     @property
     def nfaces(self):
@@ -568,5 +570,36 @@ def _submesh_for_hypercube(shape: Hypercube, node_tuples):
 
 # }}}
 
+
+# {{{ tensor product shape
+
+@dataclass(frozen=True, init=False)
+class TensorProductShape(Shape):
+    def __init__(self, bases: Tuple[Shape]):
+        self.bases = bases
+
+    @property
+    def dim(self):
+        return sum(s.dim for s in self.bases)
+
+    @property
+    def nvertices(self):
+        from math import prod
+        return prod(s.nvertices for s in self.bases)
+
+    @property
+    def nfaces(self):
+        # FIXME: is there a formula for this?
+        raise NotImplementedError
+
+
+@unit_vertices_for_shape.register(TensorProductShape)
+def _unit_vertices_for_tp(shape: TensorProductShape):
+    from modepy.nodes import tensor_product_nodes
+    return tensor_product_nodes([
+        unit_vertices_for_shape(s) for s in shape.bases
+        ])
+
+# }}}
 
 # vim: foldmethod=marker

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -205,6 +205,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from abc import ABC, abstractproperty
 import numpy as np
 from typing import Any, Callable, Sequence, Tuple, Dict
 
@@ -214,8 +215,9 @@ from dataclasses import dataclass
 
 # {{{ interface
 
-@dataclass(frozen=True)
-class Shape:
+@dataclass(frozen=True)  # type: ignore[misc]
+# https://github.com/python/mypy/issues/11868
+class Shape(ABC):
     """
     .. attribute :: dim
     .. attribute :: nfaces
@@ -223,13 +225,13 @@ class Shape:
     """
     dim: int
 
-    @property
+    @abstractproperty
     def nvertices(self):
-        raise NotImplementedError
+        pass
 
-    @property
+    @abstractproperty
     def nfaces(self):
-        raise NotImplementedError
+        pass
 
 
 @singledispatch

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -205,7 +205,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 import numpy as np
 from typing import Any, Callable, Sequence, Tuple, Dict
 
@@ -225,11 +225,13 @@ class Shape(ABC):
     """
     dim: int
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def nvertices(self):
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def nfaces(self):
         pass
 

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -177,7 +177,7 @@ class TensorProductSpace(FunctionSpace):
         self.bases = bases
 
     @property
-    def order(self):
+    def order(self) -> Tuple[int, ...]:
         return tuple([space.order for space in self.bases])
 
     @property

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -33,7 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from functools import singledispatch
 from numbers import Number
 from typing import Any, Tuple, Union
@@ -59,11 +59,13 @@ class FunctionSpace(ABC):
         The number of dimensions of the function space.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def spatial_dim(self) -> int:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def space_dim(self) -> int:
         pass
 

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -33,6 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from abc import ABC, abstractproperty
 from functools import singledispatch
 from numbers import Number
 from typing import Any, Tuple, Union
@@ -44,7 +45,7 @@ from modepy.shapes import Shape, Simplex, Hypercube, TensorProductShape
 
 # {{{ function spaces
 
-class FunctionSpace:
+class FunctionSpace(ABC):
     r"""An opaque object representing a finite-dimensional function space
     of functions :math:`\mathbb{R}^n \to \mathbb{R}`.
 
@@ -57,13 +58,13 @@ class FunctionSpace:
 
         The number of dimensions of the function space.
     """
-    @property
+    @abstractproperty
     def spatial_dim(self) -> int:
-        raise NotImplementedError
+        pass
 
-    @property
+    @abstractproperty
     def space_dim(self) -> int:
-        raise NotImplementedError
+        pass
 
 
 @singledispatch

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -58,6 +58,7 @@ class FunctionSpace(ABC):
 
         The number of dimensions of the function space.
     """
+
     @abstractproperty
     def spatial_dim(self) -> int:
         pass
@@ -74,7 +75,13 @@ def space_for_shape(
     r"""Return an unspecified instance of :class:`FunctionSpace` suitable
     for approximation on *shape* attaining interpolation error of
     :math:`O(h^{\text{order}+1})`.
+
+    :arg order: an integer interpolation order or a :class:`tuple` of orders.
+        Taking a :class:`tuple` of orders is not supported by all function
+        spaces. A notable exception being :class:`TensorProductSpace`,
+        which allows defining different orders for each base space.
     """
+
     raise NotImplementedError(type(shape).__name__)
 
 # }}}
@@ -189,7 +196,8 @@ class PN(FunctionSpace):
 
 
 @space_for_shape.register(Simplex)
-def _space_for_simplex(shape: Simplex, order: int):
+def _space_for_simplex(shape: Simplex, order: Union[int, Tuple[int, ...]]) -> PN:
+    assert isinstance(order, int)
     return PN(shape.dim, order)
 
 # }}}

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -101,7 +101,6 @@ class TensorProductSpace(FunctionSpace):
             return FunctionSpace.__new__(cls)
 
     def __init__(self, bases: Tuple[FunctionSpace, ...]) -> None:
-        # FIXME: should understand the type
         self.bases = sum([
             space.bases if isinstance(space, TensorProductSpace) else (space,)
             for space in bases
@@ -132,7 +131,10 @@ def _space_for_tensor_product_shape(
         orders = (order,) * nbases
     else:
         assert isinstance(order, tuple)
-        assert len(order) == nbases
+        if len(order) != nbases:
+            raise ValueError("must provide one order per base shape in 'shape'; "
+                    f"got {order} for {len(shape.bases)} tensor product shapes")
+
         orders = order
 
     return TensorProductSpace(tuple([
@@ -186,7 +188,7 @@ class PN(FunctionSpace):
 
 
 @space_for_shape.register(Simplex)
-def _space_for_simplex(shape: Simplex, order: int) -> PN:
+def _space_for_simplex(shape: Simplex, order: int):
     return PN(shape.dim, order)
 
 # }}}

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -37,6 +37,8 @@ from functools import singledispatch
 from numbers import Number
 from typing import Union, Tuple
 
+import numpy as np
+
 from modepy.shapes import Shape, Simplex, Hypercube
 
 
@@ -184,8 +186,7 @@ class TensorProductSpace(FunctionSpace):
 
     @property
     def space_dim(self) -> int:
-        import math
-        return math.prod(space.space_dim for space in self.bases)
+        return np.prod([space.space_dim for space in self.bases])
 
 # }}}
 

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -7,12 +7,8 @@ Function Spaces
 .. autoclass:: FunctionSpace
 .. autoclass:: PN
 .. autoclass:: QN
-.. autofunction:: space_for_shape
-
-.. autoclass:: TensorProductBaseSpace
 .. autoclass:: TensorProductSpace
-.. autoclass:: legendre_tensor_product_space
-.. autoclass:: legendre_gauss_lobatto_tensor_product_space
+.. autofunction:: space_for_shape
 """
 
 __copyright__ = "Copyright (C) 2020 Andreas Kloeckner"

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -40,7 +40,7 @@ from typing import Any, Tuple, Union
 
 import numpy as np
 
-from modepy.shapes import Shape, Simplex, Hypercube, TensorProductShape
+from modepy.shapes import Shape, Simplex, TensorProductShape
 
 
 # {{{ function spaces
@@ -113,6 +113,14 @@ class TensorProductSpace(FunctionSpace):
             space.bases if isinstance(space, TensorProductSpace) else (space,)
             for space in bases
             ], ())
+
+    @property
+    def order(self):
+        from pytools import is_single_valued
+        if is_single_valued([space.order for space in self.bases]):
+            return self.bases[0].order
+        else:
+            raise AttributeError(f"{type(self).__name__} has no attribute 'order'")
 
     @property
     def spatial_dim(self) -> int:
@@ -237,22 +245,6 @@ class QN(TensorProductSpace):
         return (f"{type(self).__name__}("
                 f"spatial_dim={self.spatial_dim}, order={self.order}"
                 ")")
-
-
-@space_for_shape.register(Hypercube)
-def _space_for_hypercube(
-        shape: Hypercube, order: Union[int, Tuple[int, ...]]
-        ) -> TensorProductSpace:
-    if isinstance(order, Number):
-        assert isinstance(order, int)
-        return QN(shape.dim, order)
-    else:
-        assert isinstance(order, tuple)
-        if len(order) != shape.dim:
-            raise ValueError("must provide one order per dimension; "
-                    f"got {order} for a {shape.dim}d hypercube")
-
-        return TensorProductSpace(tuple([PN(1, n) for n in order]))
 
 # }}}
 

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -311,6 +311,7 @@ def _evaluate_lebesgue_function(n, nodes, shape):
     basis = basis_for_space(space, shape)
     equi_node_tuples = node_tuples_for_space(huge_space)
     equi_nodes = (np.array(equi_node_tuples, dtype=np.float64)/huge_n*2 - 1).T
+    assert nodes.shape[0] == equi_nodes.shape[0]
 
     from modepy.matrices import vandermonde
     vdm = vandermonde(basis.functions, nodes)

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -258,6 +258,7 @@ def hypercube_submesh(node_tuples):
 
 
 # {{{ plotting helpers
+
 def plot_element_values(n, nodes, values, resample_n=None,
         node_tuples=None, show_nodes=False):
     dims = len(nodes)
@@ -311,7 +312,7 @@ def _evaluate_lebesgue_function(n, nodes, shape):
     basis = basis_for_space(space, shape)
     equi_node_tuples = node_tuples_for_space(huge_space)
     equi_nodes = (np.array(equi_node_tuples, dtype=np.float64)/huge_n*2 - 1).T
-    assert nodes.shape[0] == equi_nodes.shape[0]
+    assert equi_nodes.shape[0] == nodes.shape[0]
 
     from modepy.matrices import vandermonde
     vdm = vandermonde(basis.functions, nodes)

--- a/test/test_modes.py
+++ b/test/test_modes.py
@@ -120,19 +120,12 @@ def test_basis_orthogonality(shape, order, ebound):
 # {{{ test_basis_grad
 
 def get_inhomogeneous_tensor_prod_basis(space, shape):
-    if not isinstance(shape, mp.Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+    if space.spatial_dim == 1:
+        return mp.basis_for_space(space, shape)
 
-    # FIXME: Yuck. A total lie. Not a basis for the space at all.
-    assert isinstance(space, mp.QN)
-    orders = (3, 5, 7)[:space.spatial_dim]
-
-    return mp.TensorProductBasis(
-            [[partial(mp.jacobi, 0, 0, n) for n in range(o)]
-                for o in orders],
-            [[partial(mp.grad_jacobi, 0, 0, n) for n in range(o)]
-                for o in orders],
-            orth_weight=1)
+    orders = (space.order, 2, 7)[:space.spatial_dim]
+    space = mp.space_for_shape(shape, orders)
+    return mp.basis_for_space(space, shape)
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])

--- a/test/test_modes.py
+++ b/test/test_modes.py
@@ -21,7 +21,6 @@ THE SOFTWARE.
 """
 
 
-from functools import partial
 import numpy as np
 import numpy.linalg as la
 import pytest

--- a/test/test_modes.py
+++ b/test/test_modes.py
@@ -191,7 +191,9 @@ def test_basis_grad(dim, shape_cls, order, basis_getter):
 # {{{ test symbolic modes
 
 class MyStringifyMapper(CSESplittingStringifyMapperMixin, StringifyMapper):
-    pass
+    def map_slice(self, expr):
+        print(expr)
+        return "1"
 
 
 class MyEvaluationMapper(EvaluationMapper):
@@ -236,9 +238,11 @@ def test_symbolic_basis(shape, order, basis_getter):
 
         sym_val = MyEvaluationMapper({"r": r, "abs": abs})(sym_func)
         ref_val = func(r)
+        print(repr(sym_val))
+        print(repr(ref_val))
 
         ref_norm = la.norm(ref_val, np.inf)
-        err = la.norm(sym_val-ref_val, np.inf)
+        err = la.norm(sym_val - ref_val, np.inf)
         if ref_norm:
             err = err/ref_norm
 

--- a/test/test_modes.py
+++ b/test/test_modes.py
@@ -191,9 +191,7 @@ def test_basis_grad(dim, shape_cls, order, basis_getter):
 # {{{ test symbolic modes
 
 class MyStringifyMapper(CSESplittingStringifyMapperMixin, StringifyMapper):
-    def map_slice(self, expr):
-        print(expr)
-        return "1"
+    pass
 
 
 class MyEvaluationMapper(EvaluationMapper):
@@ -238,11 +236,9 @@ def test_symbolic_basis(shape, order, basis_getter):
 
         sym_val = MyEvaluationMapper({"r": r, "abs": abs})(sym_func)
         ref_val = func(r)
-        print(repr(sym_val))
-        print(repr(ref_val))
 
         ref_norm = la.norm(ref_val, np.inf)
-        err = la.norm(sym_val - ref_val, np.inf)
+        err = la.norm(sym_val-ref_val, np.inf)
         if ref_norm:
             err = err/ref_norm
 

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -267,6 +267,23 @@ def test_tensor_product_nodes_vs_tuples():
 # }}}
 
 
+# {{{ test_random_nodes_for_tensor_product
+
+def test_random_nodes_for_tensor_product():
+    import modepy as mp
+    shape = mp.TensorProductShape((mp.Simplex(1), mp.Simplex(2)))
+
+    nnodes = 10
+    nodes = mp.random_nodes_for_shape(shape, nnodes)
+    assert nodes.shape == (3, 10)
+
+    nnodes = 1
+    nodes = mp.random_nodes_for_shape(shape, nnodes)
+    assert nodes.shape == (3, 1)
+
+# }}}
+
+
 # You can test individual routines by typing
 # $ python test_nodes.py 'test_routine()'
 

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -137,6 +137,7 @@ def test_simplex_nodes(dims, n):
 def test_affine_map():
     """Check that our cheapo geometry-targeted linear algebra actually works."""
     from modepy.tools import AffineMap
+
     for d in range(1, 5):
         for _i in range(100):
             a = np.random.randn(d, d)+10*np.eye(d)
@@ -204,6 +205,8 @@ def test_order0_nodes(dim, shape_cls):
 # }}}
 
 
+# {{{ test_tensor_product_shape_nodes
+
 @pytest.mark.parametrize("shape", ["square", "cube", "squared_cube", "prism"])
 def test_tensor_product_shape_nodes(shape, visualize=False):
     order = (5, 3, 4)
@@ -240,6 +243,8 @@ def test_tensor_product_shape_nodes(shape, visualize=False):
     ax.set_ylabel("$y$")
     ax.set_zlabel("$z$")
     plt.show(block=True)
+
+# }}}
 
 
 # You can test individual routines by typing

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -204,6 +204,44 @@ def test_order0_nodes(dim, shape_cls):
 # }}}
 
 
+@pytest.mark.parametrize("shape", ["square", "cube", "squared_cube", "prism"])
+def test_tensor_product_shape_nodes(shape, visualize=False):
+    order = (5, 3, 4)
+
+    if shape == "square":
+        nodes = [nd.equidistant_nodes(1, n)[0] for n in order[:2]]
+    elif shape == "cube":
+        nodes = [nd.equidistant_nodes(1, n)[0] for n in order[:3]]
+    elif shape == "squared_cube":
+        square = nd.tensor_product_nodes([
+            nd.equidistant_nodes(1, n)[0] for n in order[:2]
+            ])
+        nodes = [square, nd.equidistant_nodes(1, order[2])[0]]
+    elif shape == "prism":
+        triangle = nd.warp_and_blend_nodes(2, order[0])
+        nodes = [triangle, nd.equidistant_nodes(1, order[1])[0]]
+    else:
+        raise ValueError(f"unknown shape name: '{shape}'")
+
+    nodes = nd.tensor_product_nodes(nodes)
+
+    if not visualize or nodes.shape[0] <= 2:
+        return
+
+    import matplotlib.pyplot as plt
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="3d")
+
+    ax.scatter(*nodes)
+    for i in range(nodes.shape[1]):
+        ax.text(*nodes[:, i], f"{i}")
+
+    ax.set_xlabel("$x$")
+    ax.set_ylabel("$y$")
+    ax.set_zlabel("$z$")
+    plt.show(block=True)
+
+
 # You can test individual routines by typing
 # $ python test_nodes.py 'test_routine()'
 

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -247,6 +247,26 @@ def test_tensor_product_shape_nodes(shape, visualize=False):
 # }}}
 
 
+# {{{ test_tensor_product_nodes_vs_tuples
+
+def test_tensor_product_nodes_vs_tuples():
+    import modepy as mp
+    shapes = [
+            (shp.Hypercube(2), (3, 5)),
+            (shp.Hypercube(3), (3, 5, 4)),
+            ]
+
+    for shape, order in shapes:
+        space = mp.space_for_shape(shape, order)
+        ref_nodes = nd.equispaced_nodes_for_space(space, shape)
+        nodes = (np.array(nd.node_tuples_for_space(space), dtype=np.float64)
+                / np.array(order[::-1]) * 2 - 1).T
+
+        assert np.linalg.norm(nodes - ref_nodes) < 1.0e-14
+
+# }}}
+
+
 # You can test individual routines by typing
 # $ python test_nodes.py 'test_routine()'
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -249,7 +249,10 @@ def _test_diff_matrix(space, shape, rtol=2.0e-4):
     (mp.Hypercube, (6, 7, 5))])
 def test_diff_matrix(dims, shape_cls, order):
     if isinstance(order, tuple):
-        order = order[:dims]
+        if dims == 1:
+            order = order[dims]
+        else:
+            order = order[:dims]
 
     shape = shape_cls(dims)
     space = mp.space_for_shape(shape, order)
@@ -527,6 +530,37 @@ def test_normals(shape):
                 (face_vertices[:, i+1] - face_vertices[:, 0]) @ normal) < 1e-13
 
         assert abs(la.norm(normal, 2) - 1) < 1e-13
+
+# }}}
+
+
+# {{{ test_tensor_product_shapes
+
+def test_tensor_product_shapes():
+    # shape, dim, nvertices, nfaces
+    shapes = [
+            (mp.Hypercube(1), 1, 2, 2),
+            (mp.Hypercube(2), 2, 4, 4),
+            (mp.Hypercube(3), 3, 8, 6),
+            (mp.TensorProductShape((mp.Simplex(1),) * 2), 2, 4, 4),
+            (mp.TensorProductShape((mp.Simplex(1),) * 3), 3, 8, 6),
+            (mp.TensorProductShape((mp.Hypercube(1), mp.Hypercube(2))), 3, 8, 6),
+            (mp.TensorProductShape((mp.Simplex(2), mp.Simplex(1))), 3, 6, 5),
+            (mp.TensorProductShape((mp.Simplex(1), mp.Simplex(2))), 3, 6, 5),
+            ]
+
+    assert isinstance(mp.Hypercube(1), mp.Simplex)
+    assert isinstance(mp.TensorProductShape((mp.Simplex(2),)), mp.Simplex)
+
+    for shape, dim, nvertices, nfaces in shapes:
+        assert shape.dim == dim
+        assert shape.nvertices == nvertices
+        assert shape.nfaces == nfaces
+
+    with pytest.raises(NotImplementedError):
+        mp.TensorProductShape((mp.Simplex(2),) * 2)
+
+    mp.faces_for_shape(mp.Hypercube(3))
 
 # }}}
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -178,8 +178,6 @@ def test_resampling_matrix(dims, shape_cls, ncoarse=5, nfine=10):
     mp.TensorProductSpace((mp.QN(2, 3), mp.QN(1, 2))),
     ])
 def test_non_homogeneous_tensor_product_resampling(space_nh):
-    logging.basicConfig(level=logging.INFO)
-
     shape = mp.Hypercube(space_nh.spatial_dim)
     orders_h = 5
 
@@ -439,7 +437,6 @@ def test_nodal_mass_matrix_for_face(dims, shape_cls, order=3):
 @pytest.mark.parametrize("order", [3, 5, 8])
 @pytest.mark.parametrize("shape_cls", [mp.Simplex, mp.Hypercube])
 def test_estimate_lebesgue_constant(dims, order, shape_cls, visualize=False):
-    logging.basicConfig(level=logging.INFO)
     shape = shape_cls(dims)
     space = mp.space_for_shape(shape, order)
 


### PR DESCRIPTION
Introduces a `TensorProductSpace` that just takes a bunch of other `Spaces` that it then uses to construct the higher dimensional stuff in `othonormal_basis_for_space` and friends. There's also a `TensorProductShape`, but that doesn't do anything at the moment.

TODO
- [x] Add some tests
- [x] Extend `tensor_product_nodes` to take nodes with different dimensions
- [x] Extend `_TensorProductBasis` to work with nodes of different dimensions
