### PR TITLE
Add more typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,23 @@ jobs:
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
                 . ./build-and-test-py-project.sh
 
+    mypy:
+        name: Mypy
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: actions/checkout@v2
+        -
+            uses: actions/setup-python@v1
+            with:
+                python-version: '3.x'
+        -   name: "Main Script"
+            run: |
+                curl -L -O https://tiker.net/ci-support-v0
+                . ./ci-support-v0
+                build_py_project_in_conda_env
+                python -m pip install mypy
+                ./run-mypy.sh
+
     docs:
         name: Documentation
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,8 @@ jobs:
                 python-version: '3.x'
         -   name: "Main Script"
             run: |
-                curl -L -O https://tiker.net/ci-support-v0
-                . ./ci-support-v0
-                build_py_project_in_conda_env
-                python -m pip install mypy
-                ./run-mypy.sh
+                curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/prepare-and-run-mypy.sh
+                . ./prepare-and-run-mypy.sh python3 mypy
 
     docs:
         name: Documentation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,3 +39,15 @@ Flake8:
   - python3
   except:
   - tags
+
+Mypy:
+  script: |
+    curl -L -O https://tiker.net/ci-support-v0
+    . ./ci-support-v0
+    build_py_project_in_venv
+    python -m pip install mypy
+    ./run-mypy.sh
+  tags:
+  - python3
+  except:
+  - tags

--- a/modepy/matrices.py
+++ b/modepy/matrices.py
@@ -262,7 +262,8 @@ def modal_mass_matrix_for_face(face: Face, face_quad: Quadrature,
     .. versionadded:: 2020.3
     """
 
-    mapped_nodes = face.map_to_volume(face_quad.nodes)
+    # NOTE: https://github.com/python/mypy/issues/9975
+    mapped_nodes = face.map_to_volume(face_quad.nodes)  # type: ignore[misc,operator]
 
     result = np.empty((len(test_functions), len(trial_functions)))
 
@@ -326,7 +327,8 @@ def nodal_quad_mass_matrix_for_face(face: Face, face_quad: Quadrature,
     """
     vol_vdm = vandermonde(test_functions, volume_nodes)
 
-    mapped_nodes = face.map_to_volume(face_quad.nodes)
+    # NOTE: https://github.com/python/mypy/issues/9975
+    mapped_nodes = face.map_to_volume(face_quad.nodes)  # type:ignore[misc, operator]
 
     vol_modal_mass_matrix = np.empty((len(test_functions), len(face_quad.weights)))
 

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -31,13 +31,15 @@ import numpy as np
 
 from modepy.spaces import FunctionSpace, PN, QN
 from modepy.shapes import Shape, Simplex, Hypercube
-from pytools import T
 
 
 __doc__ = """This functionality provides sets of basis functions for the
 reference elements in :mod:`modepy.shapes`.
 
 .. currentmodule:: modepy
+
+.. class:: T
+
 
 Basis Retrieval
 ---------------
@@ -129,7 +131,7 @@ def _where(op_a, comp, op_b, then, else_):
 
 # {{{ jacobi polynomials
 
-def jacobi(alpha: float, beta: float, n: int, x: T) -> T:
+def jacobi(alpha: float, beta: float, n: int, x: np.ndarray) -> np.ndarray:
     r"""Evaluate `Jacobi polynomials
     <https://en.wikipedia.org/wiki/Jacobi_polynomials>`_ of type
     :math:`(\alpha, \beta)`, with :math:`\alpha, \beta > -1`, and order *n*
@@ -145,7 +147,7 @@ def jacobi(alpha: float, beta: float, n: int, x: T) -> T:
     :returns: a vector of :math:`P^{(\alpha, \beta)}_n` evaluated at all *x*.
     """
 
-    from modepy.tools import gamma
+    from math import gamma
 
     # Initial values P_0(x) and P_1(x)
     # NOTE: general formula gets a divide by 0 in the `alpha + beta == -1` case,
@@ -190,7 +192,7 @@ def jacobi(alpha: float, beta: float, n: int, x: T) -> T:
     return pl[n]
 
 
-def grad_jacobi(alpha: float, beta: float, n: int, x: T) -> T:
+def grad_jacobi(alpha: float, beta: float, n: int, x: np.ndarray) -> np.ndarray:
     """Evaluate the derivative of :func:`jacobi`, with the same meanings and
     restrictions for all arguments.
     """
@@ -204,7 +206,9 @@ def grad_jacobi(alpha: float, beta: float, n: int, x: T) -> T:
 
 # {{{ 2D PKDO
 
-def _rstoab(r: T, s: T, tol: float = 1.0e-12,) -> Tuple[T, T]:
+def _rstoab(
+        r: np.ndarray, s: np.ndarray,
+        tol: float = 1.0e-12) -> Tuple[np.ndarray, np.ndarray]:
     """Transfer from (r, s) -> (a, b) coordinates in triangle."""
 
     # We may divide by zero below (or close to it), but we won't use the
@@ -215,7 +219,7 @@ def _rstoab(r: T, s: T, tol: float = 1.0e-12,) -> Tuple[T, T]:
     return a, b
 
 
-def pkdo_2d(order: Tuple[int, int], rs: T) -> T:
+def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> np.ndarray:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
     :param order: A tuple *(i, j)* representing the order of the polynomial.
@@ -230,7 +234,7 @@ def pkdo_2d(order: Tuple[int, int], rs: T) -> T:
     * |dubiner-ref|
     """
 
-    a, b = _rstoab(*rs)
+    a, b = _rstoab(*rs)     # type: ignore[misc]
     i, j = order
 
     h1 = jacobi(0, 0, i, a)
@@ -238,7 +242,9 @@ def pkdo_2d(order: Tuple[int, int], rs: T) -> T:
     return sqrt(2)*h1*h2*(1-b)**i
 
 
-def grad_pkdo_2d(order: Tuple[int, int], rs: T) -> Tuple[T, T]:
+def grad_pkdo_2d(
+        order: Tuple[int, int],
+        rs: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Evaluate the derivatives of :func:`pkdo_2d`.
 
     :param order: A tuple *(i, j)* representing the order of the polynomial.
@@ -254,7 +260,7 @@ def grad_pkdo_2d(order: Tuple[int, int], rs: T) -> Tuple[T, T]:
     * |dubiner-ref|
     """
 
-    a, b = _rstoab(*rs)
+    a, b = _rstoab(*rs)     # type: ignore[misc]
     i, j = order
 
     fa = _cse(jacobi(0, 0, i, a), f"leg_{i}")
@@ -292,7 +298,9 @@ def grad_pkdo_2d(order: Tuple[int, int], rs: T) -> Tuple[T, T]:
 
 # {{{ 3D PKDO
 
-def _rsttoabc(r: T, s: T, t: T, tol: float = 1.0e-10) -> Tuple[T, T, T]:
+def _rsttoabc(
+        r: np.ndarray, s: np.ndarray, t: np.ndarray,
+        tol: float = 1.0e-10) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     # We may divide by zero below (or close to it), but we won't use the
     # results because of the conditional. Silence the resulting numpy warnings.
     with np.errstate(all="ignore"):
@@ -303,7 +311,7 @@ def _rsttoabc(r: T, s: T, t: T, tol: float = 1.0e-10) -> Tuple[T, T, T]:
     return a, b, c
 
 
-def pkdo_3d(order: Tuple[int, int, int], rst: T) -> T:
+def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> np.ndarray:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
     :param order: A tuple *(i, j, k)* representing the order of the polynomial.
@@ -318,7 +326,7 @@ def pkdo_3d(order: Tuple[int, int, int], rst: T) -> T:
     * |dubiner-ref|
     """
 
-    a, b, c = _rsttoabc(*rst)
+    a, b, c = _rsttoabc(*rst)       # type: ignore[misc]
     i, j, k = order
 
     h1 = jacobi(0, 0, i, a)
@@ -328,7 +336,9 @@ def pkdo_3d(order: Tuple[int, int, int], rst: T) -> T:
     return 2*sqrt(2)*h1*h2*((1-b)**i)*h3*((1-c)**(i+j))
 
 
-def grad_pkdo_3d(order: Tuple[int, int, int], rst: T) -> Tuple[T, T, T]:
+def grad_pkdo_3d(
+        order: Tuple[int, int, int],
+        rst: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Evaluate the derivatives of :func:`pkdo_3d`.
 
     :param order: A tuple *(i, j, k)* representing the order of the polynomial.
@@ -344,7 +354,7 @@ def grad_pkdo_3d(order: Tuple[int, int, int], rst: T) -> Tuple[T, T, T]:
     * |dubiner-ref|
     """
 
-    a, b, c = _rsttoabc(*rst)
+    a, b, c = _rsttoabc(*rst)       # type: ignore[misc]
     i, j, k = order
 
     fa = _cse(jacobi(0, 0, i, a), f"leg_{i}")
@@ -396,7 +406,7 @@ def grad_pkdo_3d(order: Tuple[int, int, int], rst: T) -> Tuple[T, T, T]:
 
 # {{{ monomials
 
-def monomial(order: Tuple[int, ...], rst: T) -> T:
+def monomial(order: Tuple[int, ...], rst: np.ndarray) -> np.ndarray:
     """Evaluate the monomial of order *order* at the points *rst*.
 
     :param order: A tuple *(i, j,...)* representing the order of the polynomial.
@@ -410,7 +420,7 @@ def monomial(order: Tuple[int, ...], rst: T) -> T:
     return product(rst[i] ** order[i] for i in range(dim))
 
 
-def grad_monomial(order: Tuple[int, ...], rst: T) -> T:
+def grad_monomial(order: Tuple[int, ...], rst: np.ndarray) -> Tuple[np.ndarray, ...]:
     """Evaluate the derivative of the monomial of order *order* at the points *rst*.
 
     :param order: A tuple *(i, j,...)* representing the order of the polynomial.
@@ -744,8 +754,8 @@ def grad_legendre_tensor_product_basis(dims, order):
 # {{{ conversion to symbolic
 
 def symbolicize_function(
-        f: Callable[[T], Union[T, Tuple[T, ...]]], dim: int,
-        ref_coord_var_name: str = "r") -> Any:
+        f: Callable[[np.ndarray], Union[np.ndarray, Tuple[np.ndarray, ...]]],
+        dim: int, ref_coord_var_name: str = "r") -> Any:
     """For a function *f* (basis or gradient) returned by one of the functions in
     this module, return a :mod:`pymbolic` expression representing the
     same function.
@@ -847,7 +857,7 @@ def monomial_basis_for_space(space: FunctionSpace, shape: Shape) -> Basis:
 # }}}
 
 
-def zerod_basis(x: T) -> T:
+def zerod_basis(x: np.ndarray) -> np.ndarray:
     assert len(x) == 0
     x_sub = np.ones(x.shape[1:], x.dtype)
     return 1 + x_sub
@@ -855,13 +865,13 @@ def zerod_basis(x: T) -> T:
 
 # {{{ PN bases
 
-def _pkdo_1d(order: Tuple[int], r: T) -> T:
+def _pkdo_1d(order: Tuple[int], r: np.ndarray) -> np.ndarray:
     i, = order
     r0, = r
     return jacobi(0, 0, i, r0)
 
 
-def _grad_pkdo_1d(order: Tuple[int], r: T) -> Tuple[T]:
+def _grad_pkdo_1d(order: Tuple[int], r: np.ndarray) -> Tuple[np.ndarray]:
     i, = order
     r0, = r
     return (grad_jacobi(0, 0, i, r0),)
@@ -929,7 +939,7 @@ class _SimplexMonomialBasis(_SimplexBasis):
 @basis_for_space.register(PN)
 def _basis_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     if space.spatial_dim <= 3:
         return _SimplexONB(space.spatial_dim, space.order)
@@ -940,7 +950,7 @@ def _basis_for_pn(space: PN, shape: Simplex):
 @orthonormal_basis_for_space.register(PN)
 def _orthonormal_basis_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     return _SimplexONB(space.spatial_dim, space.order)
 
@@ -948,7 +958,7 @@ def _orthonormal_basis_for_pn(space: PN, shape: Simplex):
 @monomial_basis_for_space.register(PN)
 def _monomial_basis_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     return _SimplexMonomialBasis(space.spatial_dim, space.order)
 
@@ -964,8 +974,10 @@ class TensorProductBasis(Basis):
     """
 
     def __init__(self,
-            bases_1d: Sequence[Sequence[Callable[[T], T]]],
-            grad_bases_1d: Sequence[Sequence[Callable[[T], Tuple[T, ...]]]],
+            bases_1d: Sequence[Sequence[
+                Callable[[np.ndarray], np.ndarray]]],
+            grad_bases_1d: Sequence[Sequence[
+                Callable[[np.ndarray], Tuple[np.ndarray, ...]]]],
             orth_weight: Optional[float]) -> None:
         """
         :param bases_1d: a sequence (one entry per axis/dimension)
@@ -1027,20 +1039,22 @@ class TensorProductBasis(Basis):
 @orthonormal_basis_for_space.register(QN)
 def _orthonormal_basis_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     order = space.order
     dim = space.spatial_dim
     return TensorProductBasis(
             [[partial(jacobi, 0, 0, n) for n in range(order + 1)]] * dim,
-            [[partial(grad_jacobi, 0, 0, n) for n in range(order + 1)]] * dim,
+            # NOTE: https://github.com/python/mypy/issues/1484
+            [[partial(grad_jacobi, 0, 0, n)         # type: ignore[misc]
+                for n in range(order + 1)]] * dim,
             orth_weight=1)
 
 
 @basis_for_space.register(QN)
 def _basis_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     return orthonormal_basis_for_space(space, shape)
 
@@ -1059,7 +1073,7 @@ def _grad_monomial_1d(order, r):
 @monomial_basis_for_space.register(QN)
 def _monomial_basis_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
     order = space.order
     dim = space.spatial_dim

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -230,7 +230,7 @@ def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> np.ndarray:
     * |dubiner-ref|
     """
 
-    a, b = _rstoab(*rs)     # type: ignore[misc]
+    a, b = _rstoab(*rs)
     i, j = order
 
     h1 = jacobi(0, 0, i, a)
@@ -256,7 +256,7 @@ def grad_pkdo_2d(
     * |dubiner-ref|
     """
 
-    a, b = _rstoab(*rs)     # type: ignore[misc]
+    a, b = _rstoab(*rs)
     i, j = order
 
     fa = _cse(jacobi(0, 0, i, a), f"leg_{i}")
@@ -322,7 +322,7 @@ def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> np.ndarray:
     * |dubiner-ref|
     """
 
-    a, b, c = _rsttoabc(*rst)       # type: ignore[misc]
+    a, b, c = _rsttoabc(*rst)
     i, j, k = order
 
     h1 = jacobi(0, 0, i, a)
@@ -350,7 +350,7 @@ def grad_pkdo_3d(
     * |dubiner-ref|
     """
 
-    a, b, c = _rsttoabc(*rst)       # type: ignore[misc]
+    a, b, c = _rsttoabc(*rst)
     i, j, k = order
 
     fa = _cse(jacobi(0, 0, i, a), f"leg_{i}")

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -32,14 +32,10 @@ import numpy as np
 from modepy.spaces import FunctionSpace, PN, QN
 from modepy.shapes import Shape, Simplex, Hypercube
 
-
 __doc__ = """This functionality provides sets of basis functions for the
 reference elements in :mod:`modepy.shapes`.
 
 .. currentmodule:: modepy
-
-.. class:: T
-
 
 Basis Retrieval
 ---------------

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -35,18 +35,17 @@ from modepy.shapes import Shape, Simplex, Hypercube
 if TYPE_CHECKING:
     import pymbolic.primitives
 
-InputType = Union[np.ndarray, "pymbolic.primitives.Expression", float]
-InputTypeT = TypeVar("InputTypeT",
+RealValueT = TypeVar("RealValueT",
         np.ndarray, "pymbolic.primitives.Expression", float)
 
 
 __doc__ = """This functionality provides sets of basis functions for the
 reference elements in :mod:`modepy.shapes`.
 
-.. class:: InputTypeT
+.. class:: RealValueT
 
-    :class:`~typing.TypeVar` for basis function inputs, can be one of
-    :class:`numpy.ndarray`, :class:`pymbolic.primitives.Expression` or a
+    :class:`~typing.TypeVar` for basis function inputs and outputs, can be one
+    of :class:`numpy.ndarray`, :class:`pymbolic.primitives.Expression` or a
     :class:`numbers.Number`.
 
 .. currentmodule:: modepy
@@ -141,7 +140,7 @@ def _where(op_a, comp, op_b, then, else_):
 
 # {{{ jacobi polynomials
 
-def jacobi(alpha: float, beta: float, n: int, x: InputTypeT) -> InputTypeT:
+def jacobi(alpha: float, beta: float, n: int, x: RealValueT) -> RealValueT:
     r"""Evaluate `Jacobi polynomials
     <https://en.wikipedia.org/wiki/Jacobi_polynomials>`_ of type
     :math:`(\alpha, \beta)`, with :math:`\alpha, \beta > -1`, and order *n*
@@ -202,7 +201,7 @@ def jacobi(alpha: float, beta: float, n: int, x: InputTypeT) -> InputTypeT:
     return pl[n]
 
 
-def grad_jacobi(alpha: float, beta: float, n: int, x: InputTypeT) -> InputTypeT:
+def grad_jacobi(alpha: float, beta: float, n: int, x: RealValueT) -> RealValueT:
     """Evaluate the derivative of :func:`jacobi`, with the same meanings and
     restrictions for all arguments.
     """
@@ -217,8 +216,8 @@ def grad_jacobi(alpha: float, beta: float, n: int, x: InputTypeT) -> InputTypeT:
 # {{{ 2D PKDO
 
 def _rstoab(
-        r: InputTypeT, s: InputTypeT,
-        tol: float = 1.0e-12) -> Tuple[InputType, InputType]:
+        r: RealValueT, s: RealValueT,
+        tol: float = 1.0e-12) -> Tuple[RealValueT, RealValueT]:
     """Transfer from (r, s) -> (a, b) coordinates in triangle."""
 
     # We may divide by zero below (or close to it), but we won't use the
@@ -229,7 +228,7 @@ def _rstoab(
     return a, b
 
 
-def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> np.ndarray:
+def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> RealValueT:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
     :arg order: A tuple *(i, j)* representing the order of the polynomial.
@@ -254,7 +253,7 @@ def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> np.ndarray:
 
 def grad_pkdo_2d(
         order: Tuple[int, int],
-        rs: np.ndarray) -> Tuple[InputTypeT, InputTypeT]:
+        rs: np.ndarray) -> Tuple[RealValueT, RealValueT]:
     """Evaluate the derivatives of :func:`pkdo_2d`.
 
     :arg order: A tuple *(i, j)* representing the order of the polynomial.
@@ -309,8 +308,8 @@ def grad_pkdo_2d(
 # {{{ 3D PKDO
 
 def _rsttoabc(
-        r: InputTypeT, s: InputTypeT, t: InputTypeT,
-        tol: float = 1.0e-10) -> Tuple[InputType, InputType, InputType]:
+        r: RealValueT, s: RealValueT, t: RealValueT,
+        tol: float = 1.0e-10) -> Tuple[RealValueT, RealValueT, RealValueT]:
     # We may divide by zero below (or close to it), but we won't use the
     # results because of the conditional. Silence the resulting numpy warnings.
     with np.errstate(all="ignore"):
@@ -321,7 +320,7 @@ def _rsttoabc(
     return a, b, c
 
 
-def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> InputType:
+def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> RealValueT:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
     :arg order: A tuple *(i, j, k)* representing the order of the polynomial.
@@ -348,7 +347,7 @@ def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> InputType:
 
 def grad_pkdo_3d(
         order: Tuple[int, int, int],
-        rst: np.ndarray) -> Tuple[InputTypeT, InputTypeT, InputTypeT]:
+        rst: np.ndarray) -> Tuple[RealValueT, RealValueT, RealValueT]:
     """Evaluate the derivatives of :func:`pkdo_3d`.
 
     :arg order: A tuple *(i, j, k)* representing the order of the polynomial.
@@ -416,7 +415,7 @@ def grad_pkdo_3d(
 
 # {{{ monomials
 
-def monomial(order: Tuple[int, ...], rst: np.ndarray) -> InputType:
+def monomial(order: Tuple[int, ...], rst: np.ndarray) -> RealValueT:
     """Evaluate the monomial of order *order* at the points *rst*.
 
     :arg order: A tuple *(i, j,...)* representing the order of the polynomial.
@@ -430,7 +429,7 @@ def monomial(order: Tuple[int, ...], rst: np.ndarray) -> InputType:
     return product(rst[i] ** order[i] for i in range(dim))
 
 
-def grad_monomial(order: Tuple[int, ...], rst: np.ndarray) -> Tuple[InputType, ...]:
+def grad_monomial(order: Tuple[int, ...], rst: np.ndarray) -> Tuple[RealValueT, ...]:
     """Evaluate the derivative of the monomial of order *order* at the points *rst*.
 
     :arg order: A tuple *(i, j,...)* representing the order of the polynomial.
@@ -764,10 +763,10 @@ def grad_legendre_tensor_product_basis(dims, order):
 # {{{ conversion to symbolic
 
 def symbolicize_function(
-        f: Callable[[InputTypeT], Union[InputTypeT, Tuple[InputTypeT, ...]]],
+        f: Callable[[RealValueT], Union[RealValueT, Tuple[RealValueT, ...]]],
         dim: int,
         ref_coord_var_name: str = "r",
-        ) -> Union[InputTypeT, Tuple[InputTypeT, ...]]:
+        ) -> Union[RealValueT, Tuple[RealValueT, ...]]:
     """For a function *f* (basis or gradient) returned by one of the functions in
     this module, return a :mod:`pymbolic` expression representing the
     same function.

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -218,8 +218,8 @@ def _rstoab(
 def pkdo_2d(order: Tuple[int, int], rs: np.ndarray) -> np.ndarray:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
-    :param order: A tuple *(i, j)* representing the order of the polynomial.
-    :param rs: ``rs[0], rs[1]`` are arrays of :math:`(r,s)` coordinates.
+    :arg order: A tuple *(i, j)* representing the order of the polynomial.
+    :arg rs: ``rs[0], rs[1]`` are arrays of :math:`(r,s)` coordinates.
         (See :ref:`tri-coords`)
     :return: a vector of values of the same length as the *rs* arrays.
 
@@ -243,8 +243,8 @@ def grad_pkdo_2d(
         rs: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Evaluate the derivatives of :func:`pkdo_2d`.
 
-    :param order: A tuple *(i, j)* representing the order of the polynomial.
-    :param rs: ``rs[0], rs[1]`` are arrays of :math:`(r, s)` coordinates.
+    :arg order: A tuple *(i, j)* representing the order of the polynomial.
+    :arg rs: ``rs[0], rs[1]`` are arrays of :math:`(r, s)` coordinates.
         (See :ref:`tri-coords`)
     :return: a tuple of vectors *(dphi_dr, dphi_ds)*, each of the same length
         as the *rs* arrays.
@@ -310,8 +310,8 @@ def _rsttoabc(
 def pkdo_3d(order: Tuple[int, int, int], rst: np.ndarray) -> np.ndarray:
     """Evaluate a 2D orthonormal (with weight 1) polynomial on the unit simplex.
 
-    :param order: A tuple *(i, j, k)* representing the order of the polynomial.
-    :param rs: ``rst[0], rst[1], rst[2]`` are arrays of :math:`(r, s, t)`
+    :arg order: A tuple *(i, j, k)* representing the order of the polynomial.
+    :arg rs: ``rst[0], rst[1], rst[2]`` are arrays of :math:`(r, s, t)`
         coordinates. (See :ref:`tet-coords`)
     :return: a vector of values of the same length as the *rst* arrays.
 
@@ -337,8 +337,8 @@ def grad_pkdo_3d(
         rst: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Evaluate the derivatives of :func:`pkdo_3d`.
 
-    :param order: A tuple *(i, j, k)* representing the order of the polynomial.
-    :param rs: ``rs[0], rs[1], rs[2]`` are arrays of :math:`(r,s,t)` coordinates.
+    :arg order: A tuple *(i, j, k)* representing the order of the polynomial.
+    :arg rs: ``rs[0], rs[1], rs[2]`` are arrays of :math:`(r,s,t)` coordinates.
         (See :ref:`tet-coords`)
     :return: a tuple of vectors *(dphi_dr, dphi_ds, dphi_dt)*, each of the same
         length as the *rst* arrays.
@@ -405,8 +405,8 @@ def grad_pkdo_3d(
 def monomial(order: Tuple[int, ...], rst: np.ndarray) -> np.ndarray:
     """Evaluate the monomial of order *order* at the points *rst*.
 
-    :param order: A tuple *(i, j,...)* representing the order of the polynomial.
-    :param rst: ``rst[0], rst[1]`` are arrays of :math:`(r, s, ...)` coordinates.
+    :arg order: A tuple *(i, j,...)* representing the order of the polynomial.
+    :arg rst: ``rst[0], rst[1]`` are arrays of :math:`(r, s, ...)` coordinates.
         (See :ref:`tri-coords`)
     """
     dim = len(order)
@@ -419,8 +419,8 @@ def monomial(order: Tuple[int, ...], rst: np.ndarray) -> np.ndarray:
 def grad_monomial(order: Tuple[int, ...], rst: np.ndarray) -> Tuple[np.ndarray, ...]:
     """Evaluate the derivative of the monomial of order *order* at the points *rst*.
 
-    :param order: A tuple *(i, j,...)* representing the order of the polynomial.
-    :param rst: ``rst[0], rst[1]`` are arrays of :math:`(r, s, ...)` coordinates.
+    :arg order: A tuple *(i, j,...)* representing the order of the polynomial.
+    :arg rst: ``rst[0], rst[1]`` are arrays of :math:`(r, s, ...)` coordinates.
         (See :ref:`tri-coords`)
     :return: a tuple of vectors *(dphi_dr, dphi_ds, dphi_dt, ....)*, each
         of the same length as the *rst* arrays.
@@ -756,7 +756,7 @@ def symbolicize_function(
     this module, return a :mod:`pymbolic` expression representing the
     same function.
 
-    :param dim: the number of dimensions of the reference element on which
+    :arg dim: the number of dimensions of the reference element on which
         *basis* is defined.
 
     .. versionadded:: 2020.2
@@ -976,10 +976,10 @@ class TensorProductBasis(Basis):
                 Callable[[np.ndarray], Tuple[np.ndarray, ...]]]],
             orth_weight: Optional[float]) -> None:
         """
-        :param bases_1d: a sequence (one entry per axis/dimension)
+        :arg bases_1d: a sequence (one entry per axis/dimension)
             of sequences (representing the basis) of 1D functions
             representing the approximation basis.
-        :param grad_bases_1d: a sequence (one entry per axis/dimension)
+        :arg grad_bases_1d: a sequence (one entry per axis/dimension)
             representing the derivatives of *bases_1d*.
         """
         self._bases_1d = bases_1d

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -72,10 +72,10 @@ def equidistant_nodes(
         node_tuples: Optional[Sequence[Tuple[int, ...]]] = None
         ) -> np.ndarray:
     """
-    :param dims: dimensionality of desired simplex
+    :arg dims: dimensionality of desired simplex
         (e.g. 1, 2 or 3, for interval, triangle or tetrahedron).
-    :param n: Desired maximum total polynomial degree to interpolate.
-    :param node_tuples: a list of tuples of integers indicating the node order.
+    :arg n: Desired maximum total polynomial degree to interpolate.
+    :arg node_tuples: a list of tuples of integers indicating the node order.
         Use default order if *None*, see
         :func:`pytools.generate_nonnegative_integer_tuples_summing_to_at_most`.
 
@@ -294,10 +294,10 @@ def warp_and_blend_nodes(
         Journal of Engineering Mathematics 56, no. 3 (2006): 247-262.
         http://dx.doi.org/10.1007/s10665-006-9086-6
 
-    :param dims: dimensionality of desired simplex
+    :arg dims: dimensionality of desired simplex
         (1, 2 or 3, i.e. interval, triangle or tetrahedron).
-    :param n: Desired maximum total polynomial degree to interpolate.
-    :param node_tuples: a list of tuples of integers indicating the node order.
+    :arg n: Desired maximum total polynomial degree to interpolate.
+    :arg node_tuples: a list of tuples of integers indicating the node order.
         Use default order if *None*, see
         :func:`pytools.generate_nonnegative_integer_tuples_summing_to_at_most`.
     :returns: An array of shape *(dims, nnodes)* containing unit coordinates
@@ -405,7 +405,7 @@ def random_nodes_for_shape(
         shape: Shape, nnodes: int,
         rng: Optional[np.random.Generator] = None) -> np.ndarray:
     """
-    :param rng: a :class:`numpy.random.Generator`.
+    :arg rng: a :class:`numpy.random.Generator`.
 
     :returns: a :class:`numpy.ndarray` of shape `(dim, nnodes)` of random
         nodes in the reference *shape*.

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -348,7 +348,7 @@ def warp_and_blend_nodes(
 
 def tensor_product_nodes(
         dims_or_nodes: Union[int, Sequence[np.ndarray]],
-        nodes_1d: Optional[Sequence[np.ndarray]] = None) -> np.ndarray:
+        nodes_1d: Optional[np.ndarray] = None) -> np.ndarray:
     """
     :returns: an array of shape ``(dims, nnodes_1d**dims)``.
 
@@ -358,9 +358,9 @@ def tensor_product_nodes(
 
         The node ordering has changed and is no longer documented.
     """
-    from numbers import Number
-    if isinstance(dims_or_nodes, Number):
-        nodes = [nodes_1d] * dims_or_nodes
+    if isinstance(dims_or_nodes, int):
+        assert nodes_1d is not None
+        nodes: Sequence[np.ndarray] = [nodes_1d] * dims_or_nodes
         dims = dims_or_nodes
     else:
         assert nodes_1d is None
@@ -427,7 +427,7 @@ def _node_tuples_for_pn(space: PN):
 @equispaced_nodes_for_space.register(PN)
 def _equispaced_nodes_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
@@ -443,7 +443,7 @@ def _equispaced_nodes_for_pn(space: PN, shape: Simplex):
 @edge_clustered_nodes_for_space.register(PN)
 def _edge_clustered_nodes_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
@@ -487,7 +487,7 @@ def _node_tuples_for_qn(space: QN):
 @equispaced_nodes_for_space.register(QN)
 def _equispaced_nodes_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
@@ -501,7 +501,7 @@ def _equispaced_nodes_for_qn(space: QN, shape: Hypercube):
 @edge_clustered_nodes_for_space.register(QN)
 def _edge_clustered_nodes_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -54,7 +54,8 @@ THE SOFTWARE.
 
 # }}}
 
-from typing import List, Tuple
+from typing import Sequence, Optional, Tuple, Union
+
 import numpy as np
 import numpy.linalg as la
 
@@ -66,14 +67,18 @@ from modepy.spaces import FunctionSpace, PN, QN
 
 # {{{ equidistant nodes
 
-def equidistant_nodes(dims, n, node_tuples=None):
+def equidistant_nodes(
+        dims: int, n: int,
+        node_tuples: Optional[Sequence[Tuple[int, ...]]] = None
+        ) -> np.ndarray:
     """
-    :arg dims: dimensionality of desired simplex
+    :param dims: dimensionality of desired simplex
         (e.g. 1, 2 or 3, for interval, triangle or tetrahedron).
-    :arg n: Desired maximum total polynomial degree to interpolate.
-    :arg node_tuples: a list of tuples of integers indicating the node order.
+    :param n: Desired maximum total polynomial degree to interpolate.
+    :param node_tuples: a list of tuples of integers indicating the node order.
         Use default order if *None*, see
         :func:`pytools.generate_nonnegative_integer_tuples_summing_to_at_most`.
+
     :returns: An array of shape *(dims, nnodes)* containing bi-unit coordinates
         of the interpolation nodes. (see :ref:`tri-coords` and :ref:`tet-coords`)
     """
@@ -279,7 +284,9 @@ def warp_and_blend_nodes_3d(n, node_tuples=None):
 
 # {{{ generic interface to warp-and-blend nodes
 
-def warp_and_blend_nodes(dims, n, node_tuples=None):
+def warp_and_blend_nodes(
+        dims: int, n: int,
+        node_tuples: Optional[Sequence[Tuple[int, ...]]] = None) -> np.ndarray:
     """Return interpolation nodes as described in [warburton-nodes]_
 
     .. [warburton-nodes] Warburton, T.
@@ -287,10 +294,10 @@ def warp_and_blend_nodes(dims, n, node_tuples=None):
         Journal of Engineering Mathematics 56, no. 3 (2006): 247-262.
         http://dx.doi.org/10.1007/s10665-006-9086-6
 
-    :arg dims: dimensionality of desired simplex
+    :param dims: dimensionality of desired simplex
         (1, 2 or 3, i.e. interval, triangle or tetrahedron).
-    :arg n: Desired maximum total polynomial degree to interpolate.
-    :arg node_tuples: a list of tuples of integers indicating the node order.
+    :param n: Desired maximum total polynomial degree to interpolate.
+    :param node_tuples: a list of tuples of integers indicating the node order.
         Use default order if *None*, see
         :func:`pytools.generate_nonnegative_integer_tuples_summing_to_at_most`.
     :returns: An array of shape *(dims, nnodes)* containing unit coordinates
@@ -339,7 +346,9 @@ def warp_and_blend_nodes(dims, n, node_tuples=None):
 
 # {{{ tensor product nodes
 
-def tensor_product_nodes(dims_or_nodes, nodes_1d=None):
+def tensor_product_nodes(
+        dims_or_nodes: Union[int, Sequence[np.ndarray]],
+        nodes_1d: Optional[Sequence[np.ndarray]] = None) -> np.ndarray:
     """
     :returns: an array of shape ``(dims, nnodes_1d**dims)``.
 
@@ -348,7 +357,6 @@ def tensor_product_nodes(dims_or_nodes, nodes_1d=None):
     .. versionchanged:: 2020.3
 
         The node ordering has changed and is no longer documented.
-
     """
     from numbers import Number
     if isinstance(dims_or_nodes, Number):
@@ -368,7 +376,7 @@ def tensor_product_nodes(dims_or_nodes, nodes_1d=None):
     return result.reshape(dims, -1)
 
 
-def legendre_gauss_lobatto_tensor_product_nodes(dims, n):
+def legendre_gauss_lobatto_tensor_product_nodes(dims: int, n: int) -> np.ndarray:
     from modepy.quadrature.jacobi_gauss import legendre_gauss_lobatto_nodes
     return tensor_product_nodes(dims, legendre_gauss_lobatto_nodes(n))
 
@@ -378,26 +386,29 @@ def legendre_gauss_lobatto_tensor_product_nodes(dims, n):
 # {{{ space-based interface
 
 @singledispatch
-def node_tuples_for_space(space: FunctionSpace) -> List[Tuple[int]]:
+def node_tuples_for_space(space: FunctionSpace) -> Sequence[Tuple[int]]:
     raise NotImplementedError(type(space).__name__)
 
 
 @singledispatch
-def equispaced_nodes_for_space(space: FunctionSpace, shape: Shape):
-    raise NotImplementedError((type(space).__name__, type(shape).__name))
+def equispaced_nodes_for_space(space: FunctionSpace, shape: Shape) -> np.ndarray:
+    raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
 
 @singledispatch
-def edge_clustered_nodes_for_space(space: FunctionSpace, shape: Shape):
-    raise NotImplementedError((type(space).__name__, type(shape).__name))
+def edge_clustered_nodes_for_space(space: FunctionSpace, shape: Shape) -> np.ndarray:
+    raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
 
 @singledispatch
-def random_nodes_for_shape(shape: Shape, nnodes: int, rng=None):
+def random_nodes_for_shape(
+        shape: Shape, nnodes: int,
+        rng: Optional[np.random.Generator] = None) -> np.ndarray:
     """
-    :arg generator: a :class:`numpy.random.Generator`.
-    :returns: a :class:`numpy.ndarray` that returns an array of
-        shape `(dim, nnodes)` of random nodes in the reference element.
+    :param rng: a :class:`numpy.random.Generator`.
+
+    :returns: a :class:`numpy.ndarray` of shape `(dim, nnodes)` of random
+        nodes in the reference *shape*.
     """
     raise NotImplementedError(type(shape).__name__)
 

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -166,19 +166,19 @@ def quadrature_for_space(space: FunctionSpace, shape: Shape) -> Quadrature:
     :returns: a :class:`~modepy.Quadrature` that exactly integrates the functions
         in *space* over *shape*.
     """
-    raise NotImplementedError((type(space).__name__, type(shape).__name))
+    raise NotImplementedError((type(space).__name__, type(shape).__name__))
 
 
 @quadrature_for_space.register(PN)
 def _quadrature_for_pn(space: PN, shape: Simplex):
     if not isinstance(shape, Simplex):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
     import modepy as mp
     if space.spatial_dim == 0:
-        quad = ZeroDimensionalQuadrature()
+        quad: Quadrature = ZeroDimensionalQuadrature()
     else:
         try:
             quad = mp.XiaoGimbutasSimplexQuadrature(space.order, space.spatial_dim)
@@ -193,12 +193,12 @@ def _quadrature_for_pn(space: PN, shape: Simplex):
 @quadrature_for_space.register(QN)
 def _quadrature_for_qn(space: QN, shape: Hypercube):
     if not isinstance(shape, Hypercube):
-        raise NotImplementedError((type(space).__name__, type(shape).__name))
+        raise NotImplementedError((type(space).__name__, type(shape).__name__))
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
     if space.spatial_dim == 0:
-        quad = ZeroDimensionalQuadrature()
+        quad: Quadrature = ZeroDimensionalQuadrature()
     else:
         quad = LegendreGaussTensorProductQuadrature(space.order, space.spatial_dim)
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -289,7 +289,7 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
 @singledispatch
 def faces_for_shape(shape: Shape) -> Tuple[Face, ...]:
     r"""
-    :results: a tuple of :class:`Face`\ s representing the faces of *shape*.
+    :returns: a tuple of :class:`Face`\ s representing the faces of *shape*.
     """
     raise NotImplementedError(type(shape).__name__)
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -256,10 +256,6 @@ class Face:
     volume_vertex_indices: Tuple[int, ...]
     map_to_volume: Callable[[np.ndarray], np.ndarray]
 
-    @property
-    def dim(self):
-        return self.volume_shape.dim - 1
-
 
 def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     """
@@ -268,7 +264,8 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     volume_vertices = unit_vertices_for_shape(face.volume_shape)
     face_vertices = volume_vertices[:, face.volume_vertex_indices]
 
-    if face.dim == 0:
+    dim = getattr(face, "dim", face.volume_shape.dim - 1)
+    if dim == 0:
         # FIXME Grrrr. Hardcoded special case. Got a better idea?
         (fv,), = face_vertices
         return np.array([np.sign(fv)])
@@ -280,7 +277,7 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     from functools import reduce
     surface_ps = reduce(outerprod, [
         MultiVector(face_vertices[:, i+1] - face_vertices[:, 0])
-        for i in range(face.dim)])
+        for i in range(dim)])
 
     if normalize:
         surface_ps = surface_ps / np.sqrt(surface_ps.norm_squared())

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -256,6 +256,10 @@ class Face:
     volume_vertex_indices: Tuple[int, ...]
     map_to_volume: Callable[[np.ndarray], np.ndarray]
 
+    @property
+    def dim(self):
+        return self.volume_shape.dim - 1
+
 
 def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     """
@@ -337,7 +341,7 @@ def _simplex_face_to_vol_map(face_vertices, p: np.ndarray):
 @faces_for_shape.register(Simplex)
 def _faces_for_simplex(shape: Simplex):
     # NOTE: order is chosen to maintain a positive orientation
-    face_vertex_indices = {
+    face_vertex_indices: Tuple[Tuple[int, ...], ...] = {  # type: ignore[assignment]
             1: ((0,), (1,)),
             2: ((0, 1), (2, 0), (1, 2)),
             3: ((0, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3))
@@ -399,7 +403,7 @@ def _hypercube_face_to_vol_map(face_vertices: np.ndarray, p: np.ndarray):
 @faces_for_shape.register(Hypercube)
 def _faces_for_hypercube(shape: Hypercube):
     # NOTE: order is chosen to maintain a positive orientation
-    face_vertex_indices = {
+    face_vertex_indices: Tuple[Tuple[int, ...], ...] = {  # type: ignore[assignment]
         1: ((0b0,), (0b1,)),
         2: ((0b00, 0b01), (0b11, 0b10), (0b10, 0b00), (0b01, 0b11)),
         3: (

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -264,8 +264,9 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     volume_vertices = unit_vertices_for_shape(face.volume_shape)
     face_vertices = volume_vertices[:, face.volume_vertex_indices]
 
-    dim = getattr(face, "dim", face.volume_shape.dim - 1)
-    if dim == 0:
+    assert isinstance(face, Shape)
+
+    if face.dim == 0:
         # FIXME Grrrr. Hardcoded special case. Got a better idea?
         (fv,), = face_vertices
         return np.array([np.sign(fv)])
@@ -277,7 +278,7 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
     from functools import reduce
     surface_ps = reduce(outerprod, [
         MultiVector(face_vertices[:, i+1] - face_vertices[:, 0])
-        for i in range(dim)])
+        for i in range(face.dim)])
 
     if normalize:
         surface_ps = surface_ps / np.sqrt(surface_ps.norm_squared())

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -436,7 +436,7 @@ def submesh_for_shape(
     """Return a list of tuples of indices into the node list that
     generate a tesselation of the reference element.
 
-    :param node_tuples: A list of tuples *(i, j, ...)* of integers
+    :arg node_tuples: A list of tuples *(i, j, ...)* of integers
         indicating node positions inside the unit element. The
         returned list references indices in this list.
 

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -201,7 +201,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from typing import Tuple, Callable
+from typing import Callable, Sequence, Tuple
 
 from functools import singledispatch, partial
 from dataclasses import dataclass
@@ -220,7 +220,7 @@ class Shape:
 
 
 @singledispatch
-def unit_vertices_for_shape(shape: Shape):
+def unit_vertices_for_shape(shape: Shape) -> np.ndarray:
     """
     :returns: an :class:`~numpy.ndarray` of shape `(dim, nvertices)`.
     """
@@ -253,7 +253,7 @@ class Face:
     """
     volume_shape: Shape
     face_index: int
-    volume_vertex_indices: Tuple[int]
+    volume_vertex_indices: Tuple[int, ...]
     map_to_volume: Callable[[np.ndarray], np.ndarray]
 
 
@@ -286,9 +286,9 @@ def face_normal(face: Face, normalize: bool = True) -> np.ndarray:
 
 
 @singledispatch
-def faces_for_shape(shape: Shape):
-    """
-    :results: a tuple of :class:`Face` representing the faces of *shape*.
+def faces_for_shape(shape: Shape) -> Tuple[Face, ...]:
+    r"""
+    :results: a tuple of :class:`Face`\ s representing the faces of *shape*.
     """
     raise NotImplementedError(type(shape).__name__)
 
@@ -429,11 +429,13 @@ def _faces_for_hypercube(shape: Hypercube):
 # {{{ submeshes
 
 @singledispatch
-def submesh_for_shape(shape: Shape, node_tuples):
+def submesh_for_shape(
+        shape: Shape, node_tuples: Sequence[Tuple[int, ...]]
+        ) -> Sequence[Tuple[int, ...]]:
     """Return a list of tuples of indices into the node list that
     generate a tesselation of the reference element.
 
-    :arg node_tuples: A list of tuples *(i, j, ...)* of integers
+    :param node_tuples: A list of tuples *(i, j, ...)* of integers
         indicating node positions inside the unit element. The
         returned list references indices in this list.
 

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -40,7 +40,7 @@ from modepy.shapes import Shape, Simplex, Hypercube
 
 class FunctionSpace:
     r"""An opaque object representing a finite-dimensional function space
-    of functions :math:`\mathbb R^n \to \mathbb R`.
+    of functions :math:`\mathbb{R}^n \to \mathbb{R}`.
 
     .. attribute:: spatial_dim
 
@@ -51,11 +51,6 @@ class FunctionSpace:
 
         The number of dimensions of the function space.
     """
-
-    def __repr__(self) -> str:
-        return (f"{type(self).__name__}("
-            f"spatial_dim={self.spatial_dim}, space_dim={self.space_dim}"
-            ")")
 
 
 @singledispatch

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -39,47 +39,14 @@ THE SOFTWARE.
 """
 
 from functools import reduce
+from math import gamma      # noqa: F401
+from math import sqrt
 
 import numpy as np
 import numpy.linalg as la
-from math import sqrt
+
 from pytools import memoize_method, MovedFunctionDeprecationWrapper
 import modepy.shapes as shp
-
-
-try:
-    # Python 2.7 and newer
-    from math import gamma
-except ImportError:
-    _have_gamma = False
-else:
-    _have_gamma = True
-
-
-if not _have_gamma:
-    try:
-        from scipy.special import gamma  # noqa
-    except ImportError:
-        pass
-    else:
-        _have_gamma = True
-
-
-if not _have_gamma:
-    def gamma(z):  # noqa
-        from warnings import warn
-        warn("Using makeshift gamma function that only works for integers. "
-                "No better one was found.")
-
-        if z != int(z):
-            raise RuntimeError("makeshift gamma function doesn't work "
-                    "for non-integers")
-
-        g = 1
-        for i in range(1, int(z)):
-            g = g*i
-
-        return g
 
 
 class Monomial:
@@ -154,12 +121,12 @@ class AffineMap:
         # This .T goofiness allows both the nD and the 1D case.
         return (np.dot(self.a, x).T + self.b).T
 
-    @property
+    @property           # type: ignore[misc]
     @memoize_method
     def jacobian(self):
         return la.det(self.a)
 
-    @property
+    @property           # type: ignore[misc]
     @memoize_method
     def inverse(self):
         """The inverse :class:`AffineMap` of *self*."""

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -121,11 +121,13 @@ class AffineMap:
         # This .T goofiness allows both the nD and the 1D case.
         return (np.dot(self.a, x).T + self.b).T
 
+    # mypy limitation: "Decorated property not supported"
     @property           # type: ignore[misc]
     @memoize_method
     def jacobian(self):
         return la.det(self.a)
 
+    # mypy limitation: "Decorated property not supported"
     @property           # type: ignore[misc]
     @memoize_method
     def inverse(self):

--- a/run-mypy.sh
+++ b/run-mypy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -m mypy --show-error-codes modepy test

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,20 @@ docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
+
+[mypy]
+
+[mypy-mayavi.*]
+ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-pymbolic.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,6 @@ ignore_missing_imports = True
 [mypy-matplotlib.*]
 ignore_missing_imports = True
 
-[mypy-numpy.*]
-ignore_missing_imports = True
-
 [mypy-pymbolic.*]
 ignore_missing_imports = True
 

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -28,6 +28,8 @@ import modepy.shapes as shp
 import modepy.nodes as nd
 
 
+# {{{ test_barycentric_coordinate_map
+
 @pytest.mark.parametrize("dims", [1, 2, 3])
 def test_barycentric_coordinate_map(dims):
     n = 100
@@ -50,6 +52,10 @@ def test_barycentric_coordinate_map(dims):
     unit3 = equilateral_to_unit(equi)
     assert la.norm(unit-unit3) < 1e-14
 
+# }}}
+
+
+# {{{ test_warp
 
 def test_warp():
     """Check some assumptions on the node warp factor calculator"""
@@ -67,6 +73,10 @@ def test_warp():
     lgq = LegendreGaussQuadrature(n)
     assert abs(lgq(partial(nd.warp_factor, n, scaled=False))) < 6e-14
 
+# }}}
+
+
+# {{{ test_tri_face_node_distribution
 
 def test_tri_face_node_distribution():
     """Test whether the nodes on the faces of the triangle are distributed
@@ -103,10 +113,14 @@ def test_tri_face_node_distribution():
         error = la.norm(points-first_points, np.Inf)
         assert error < 1e-15
 
+# }}}
+
+
+# {{{ test_simplex_nodes
 
 @pytest.mark.parametrize("dims", [1, 2, 3])
 @pytest.mark.parametrize("n", [1, 3, 6])
-def test_simp_nodes(dims, n):
+def test_simplex_nodes(dims, n):
     """Verify basic assumptions on simplex interpolation nodes"""
 
     eps = 1e-10
@@ -115,11 +129,14 @@ def test_simp_nodes(dims, n):
     assert (unodes >= -1-eps).all()
     assert (np.sum(unodes) <= eps).all()
 
+# }}}
+
+
+# {{{ test_affine_map
 
 def test_affine_map():
     """Check that our cheapo geometry-targeted linear algebra actually works."""
     from modepy.tools import AffineMap
-    # for d in [3]:
     for d in range(1, 5):
         for _i in range(100):
             a = np.random.randn(d, d)+10*np.eye(d)
@@ -130,6 +147,10 @@ def test_affine_map():
 
             assert la.norm(x-m.inverse(m(x))) < 1e-10
 
+# }}}
+
+
+# {{{ test_tensor_product_nodes
 
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
 def test_tensor_product_nodes(dim):
@@ -141,6 +162,10 @@ def test_tensor_product_nodes(dim):
             nodes[0],
             np.array(nodes_1d.tolist() * nnodes**(dim - 1)))
 
+# }}}
+
+
+# {{{ test_nonhomogeneous_tensor_product_nodes
 
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
 def test_nonhomogeneous_tensor_product_nodes(dim):
@@ -154,6 +179,10 @@ def test_nonhomogeneous_tensor_product_nodes(dim):
             list(range(nnodes[-1])) * int(np.prod(nnodes[:-1]))
             )
 
+# }}}
+
+
+# {{{ test_order0_nodes
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
 @pytest.mark.parametrize("shape_cls", [shp.Hypercube, shp.Simplex])
@@ -171,6 +200,8 @@ def test_order0_nodes(dim, shape_cls):
     nodes = mp.edge_clustered_nodes_for_space(space, shape)
     assert not np.isnan(nodes).any()
     assert np.allclose(centroid, nodes)
+
+# }}}
 
 
 # You can test individual routines by typing


### PR DESCRIPTION
Most of this is cherrypicked from #41, since that was getting a bit unwieldy with unrelated changes. 

It contains mostly docs and typing changes, but it also has two functional changes:

* removes the `modepy.tools.gamma` function, since it was added in `math` from python 3.2. (mypy kept complaining about redefining it)
* fixes some uses of `__name` instead of `__name__` when raising some exceptions.