### PR TITLE
Use force_dim_axis everywhere

### DIFF
--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -112,7 +112,7 @@ def warp_factor(n, output_nodes, scaled=True):
 
     from modepy.quadrature.jacobi_gauss import legendre_gauss_lobatto_nodes
 
-    warped_nodes = legendre_gauss_lobatto_nodes(n)
+    warped_nodes = legendre_gauss_lobatto_nodes(n, force_dim_axis=True).squeeze()
     equi_nodes = np.linspace(-1, 1, n+1)
 
     from modepy.matrices import vandermonde
@@ -320,17 +320,19 @@ def warp_and_blend_nodes(
 
     elif dims == 1:
         from modepy.quadrature.jacobi_gauss import legendre_gauss_lobatto_nodes
-        result = legendre_gauss_lobatto_nodes(n)
+        result = legendre_gauss_lobatto_nodes(n, force_dim_axis=True)
 
         if node_tuples is not None:
             new_result = np.empty_like(result)
-            if len(node_tuples) != n+1:
+            if len(node_tuples) != n + 1:
                 raise ValueError("node_tuples list does not have the correct length")
+
             for i, (nti,) in enumerate(node_tuples):
-                new_result[i] = result[nti]
+                new_result[:, i] = result[:, nti]
+
             result = new_result
 
-        return result.reshape(1, -1)
+        return result
 
     elif dims == 2:
         return warp_and_blend_nodes_2d(n, node_tuples)
@@ -388,7 +390,8 @@ def tensor_product_nodes(
 
 def legendre_gauss_lobatto_tensor_product_nodes(dims: int, n: int) -> np.ndarray:
     from modepy.quadrature.jacobi_gauss import legendre_gauss_lobatto_nodes
-    return tensor_product_nodes(dims, legendre_gauss_lobatto_nodes(n))
+    return tensor_product_nodes(dims,
+        legendre_gauss_lobatto_nodes(n, force_dim_axis=True))
 
 # }}}
 

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -93,7 +93,7 @@ class Quadrature:
         *f* is assumed to accept arrays of shape *(dims, npts)*,
         or of shape *(npts,)* for 1D quadrature.
         """
-        return np.dot(self.weights, f(self.nodes))
+        return np.dot(self.weights, f(self.nodes).T).T
 
 
 class ZeroDimensionalQuadrature(Quadrature):

--- a/modepy/quadrature/__init__.py
+++ b/modepy/quadrature/__init__.py
@@ -155,7 +155,9 @@ class TensorProductQuadrature(Quadrature):
 class LegendreGaussTensorProductQuadrature(TensorProductQuadrature):
     def __init__(self, N, dims, backend=None):      # noqa: N803
         from modepy.quadrature.jacobi_gauss import LegendreGaussQuadrature
-        super().__init__([LegendreGaussQuadrature(N, backend=backend)] * dims)
+        super().__init__([
+            LegendreGaussQuadrature(N, backend=backend, force_dim_axis=True)
+            ] * dims)
 
 
 # {{{ quadrature

--- a/modepy/quadrature/jacobi_gauss.py
+++ b/modepy/quadrature/jacobi_gauss.py
@@ -66,7 +66,12 @@ class JacobiGaussQuadrature(Quadrature):
         if backend == "builtin":
             x, w = self.compute_weights_and_nodes(N, alpha, beta)
         elif backend == "scipy":
-            from scipy.special.orthogonal import roots_jacobi
+            try:
+                from scipy.special import roots_jacobi
+            except ImportError:
+                # NOTE: deprecated in scipy >=1.8.0
+                from scipy.special.orthogonal import roots_jacobi
+
             x, w = roots_jacobi(N + 1, alpha, beta)
         else:
             raise NotImplementedError("Unsupported backend: %s" % backend)

--- a/test/test_modes.py
+++ b/test/test_modes.py
@@ -50,7 +50,7 @@ def test_orthonormality_jacobi_1d(alpha, beta, ebound):
     from modepy.quadrature.jacobi_gauss import JacobiGaussQuadrature
 
     max_n = 10
-    quad = JacobiGaussQuadrature(alpha, beta, 4*max_n)
+    quad = JacobiGaussQuadrature(alpha, beta, 4*max_n, force_dim_axis=True)
 
     from functools import partial
     jac_f = [partial(mp.jacobi, alpha, beta, n) for n in range(max_n)]

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -70,7 +70,7 @@ def test_warp():
 
     from modepy.quadrature.jacobi_gauss import LegendreGaussQuadrature
 
-    lgq = LegendreGaussQuadrature(n)
+    lgq = LegendreGaussQuadrature(n, force_dim_axis=True)
     assert abs(lgq(partial(nd.warp_factor, n, scaled=False))) < 6e-14
 
 # }}}

--- a/test/test_quadrature.py
+++ b/test/test_quadrature.py
@@ -34,14 +34,18 @@ def test_transformed_quadrature():
     """Test 1D quadrature on arbitrary intervals"""
 
     def gaussian_density(x, mu, sigma):
-        return 1 / (sigma * np.sqrt(2*np.pi)) * np.exp(-(x-mu)**2 / (2 * sigma**2))
+        return (
+            1 / (sigma * np.sqrt(2*np.pi))
+            * np.exp(-np.sum((x-mu)**2, axis=0) / (2 * sigma**2))
+        )
 
     from modepy.quadrature import Transformed1DQuadrature
     from modepy.quadrature.jacobi_gauss import LegendreGaussQuadrature
 
     mu = 17
     sigma = 12
-    tq = Transformed1DQuadrature(LegendreGaussQuadrature(20),
+    tq = Transformed1DQuadrature(
+            LegendreGaussQuadrature(20, force_dim_axis=True),
             mu - 6*sigma, mu + 6*sigma)
 
     result = tq(lambda x: gaussian_density(x, mu, sigma))
@@ -61,10 +65,10 @@ def test_gauss_quadrature(backend):
     from modepy.quadrature.jacobi_gauss import LegendreGaussQuadrature
 
     for s in range(9 + 1):
-        quad = LegendreGaussQuadrature(s, backend)
+        quad = LegendreGaussQuadrature(s, backend, force_dim_axis=True)
         for deg in range(quad.exact_to + 1):
             def f(x):
-                return x**deg
+                return np.sum(x**deg, axis=0)
 
             i_f = quad(f)
             i_f_true = 1 / (deg+1) * (1 - (-1)**(deg + 1))
@@ -76,7 +80,7 @@ def test_clenshaw_curtis_quadrature():
     from modepy.quadrature.clenshaw_curtis import ClenshawCurtisQuadrature
 
     for s in range(1, 9 + 1):
-        quad = ClenshawCurtisQuadrature(s)
+        quad = ClenshawCurtisQuadrature(s, force_dim_axis=True)
         for deg in range(quad.exact_to + 1):
             def f(x):
                 return x**deg
@@ -93,7 +97,7 @@ def test_fejer_quadrature(kind):
 
     for deg in range(1, 9 + 1):
         s = deg * 3
-        quad = FejerQuadrature(s, kind)
+        quad = FejerQuadrature(s, kind, force_dim_axis=True)
 
         def f(x):
             return x**deg


### PR DESCRIPTION
I think these are the last places which didn't set `force_dim_axis` to `True` (at least `meshmode` does not give any more deprecation warnings).