### PR TITLE
Add `reshape_array_for_tensor_product_space`

### DIFF
--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1128,10 +1128,10 @@ class TensorProductBasis(Basis):
         if dims_per_basis is None:
             dims_per_basis = (1,) * len(bases)
 
-        self._bases = list(reversed(bases))
-        self._grad_bases = list(reversed(grad_bases))
+        self._bases = list(bases)
+        self._grad_bases = list(grad_bases)
         self._orth_weight = orth_weight
-        self._dims_per_basis = tuple(reversed(dims_per_basis))
+        self._dims_per_basis = tuple(dims_per_basis)
 
     def orthonormality_weight(self):
         if self._orth_weight is None:
@@ -1150,7 +1150,8 @@ class TensorProductBasis(Basis):
     @property
     def mode_ids(self):
         from pytools import generate_nonnegative_integer_tuples_below as gnitb
-        return tuple(gnitb([len(b) for b in self._bases]))
+        # ensure that these start numbering (0,0), (1,0), (i.e. x-axis first)
+        return tuple(mid[::-1] for mid in gnitb([len(b) for b in self._bases[::-1]]))
 
     @property
     def functions(self):

--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -366,6 +366,11 @@ def tensor_product_nodes(
 
         *dims_or_nodes* can contain nodes of general size ``(dims, nnodes)``,
         not only one dimensional nodes.
+
+    .. versionchanged:: 2022.1
+
+        The node ordering changed once again, and it is now accessible, via
+        :func:`modepy.tools.reshape_array_for_tensor_product_space`.
     """
     if isinstance(dims_or_nodes, int):
         if nodes_1d is None:

--- a/modepy/spaces.py
+++ b/modepy/spaces.py
@@ -99,6 +99,10 @@ class TensorProductSpace(FunctionSpace):
         tensor product.
 
     .. automethod:: __init__
+
+    To recover the tensor product structure of degree-of-freedom arrays (nodal
+    or modal) associated with this type of space, see
+    :func:`~modepy.tools.reshape_array_for_tensor_product_space`.
     """
 
     bases: Tuple[FunctionSpace, ...]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ def main():
               "pymbolic",
 
               "dataclasses; python_version<'3.7'",
+              "typing_extensions; python_version<'3.8'",
               ],
           package_data={"modepy": ["py.typed"]},
           )

--- a/test/test_nodes.py
+++ b/test/test_nodes.py
@@ -177,7 +177,7 @@ def test_nonhomogeneous_tensor_product_nodes(dim):
 
     assert np.allclose(
             nodes[0],
-            list(range(nnodes[-1])) * int(np.prod(nnodes[:-1]))
+            list(range(nnodes[0])) * int(np.prod(nnodes[1:]))
             )
 
 # }}}
@@ -260,7 +260,7 @@ def test_tensor_product_nodes_vs_tuples():
         space = mp.space_for_shape(shape, order)
         ref_nodes = nd.equispaced_nodes_for_space(space, shape)
         nodes = (np.array(nd.node_tuples_for_space(space), dtype=np.float64)
-                / np.array(order[::-1]) * 2 - 1).T
+                / np.array(order) * 2 - 1).T
 
         assert np.linalg.norm(nodes - ref_nodes) < 1.0e-14
 


### PR DESCRIPTION
This
- ~~flips the tensor product order (both nodes and modes), yet again.~~ This avoids a bunch of awkward reversals that were previously done.
- introduces `reshape_array_for_tensor_product_space` (and its inverse), which makes it easier to think about tensor product modes and nodes via array indices.
- It includes a test that this reshape is consistent with both mode and node ordering.
- It further includes a test that the reshape enables dimension-by-dimension operations. (shown using the Vandermonde)

Best read commit-by-commit.

cc @xywei 