### PR TITLE
docs: update intersphinx mapping from deprecated variant

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,8 +15,8 @@ version = ".".join(str(x) for x in ver_dic["VERSION"])
 release = ver_dic["VERSION_TEXT"]
 
 intersphinx_mapping = {
-        "https://docs.python.org/3/": None,
-        "https://numpy.org/doc/stable/": None,
-        "https://documen.tician.de/pytools": None,
-        "https://documen.tician.de/pymbolic": None,
-        }
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pymbolic": ("https://documen.tician.de/pymbolic", None),
+    "python": ("https://docs.python.org/3/", None),
+    "pytools": ("https://documen.tician.de/pytools", None),
+}


### PR DESCRIPTION
This was deprecated in Sphinx 6.2 and is now throwing some verbose warnings
https://www.sphinx-doc.org/en/master/changes.html#id7