### PR TITLE
Allow access to 1D tensor product bases

### DIFF
--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1120,13 +1120,13 @@ class TensorProductBasis(Basis):
             be the normalizing weight. If *None*, then the basis is assumed to
             not be orthogonal (this is not checked).
         """
-        if len(bases) != len(grad_bases):
-            raise ValueError("'bases' and 'grad_bases' must have the same length")
+        # if len(bases) != len(grad_bases):
+        #     raise ValueError("'bases' and 'grad_bases' must have the same length")
 
-        for i, (b, gb) in enumerate(zip(bases, grad_bases)):
-            if len(b) != len(gb):
-                raise ValueError(
-                        f"bases[{i}] and grad_bases[{i}] must have the same length")
+        # for i, (b, gb) in enumerate(zip(bases, grad_bases)):
+        #     if len(b) != len(gb):
+        #         raise ValueError(
+        #                 f"bases[{i}] and grad_bases[{i}] must have the same length")
 
         if dims_per_basis is None:
             dims_per_basis = (1,) * len(bases)
@@ -1175,7 +1175,9 @@ class TensorProductBasis(Basis):
     @property
     def gradients(self):
         from pytools import wandering_element
-        func = (self._bases, self._grad_bases)
+        bases = [b.functions for b in self._bases]
+        grad_bases = [b.gradients for b in self._bases]
+        func = (bases, grad_bases)
         return tuple(
                 _TensorProductGradientBasisFunction(mid, tuple([
                     tuple([
@@ -1212,8 +1214,7 @@ def _orthonormal_basis_for_tp(
     if space.spatial_dim != shape.dim:
         raise ValueError("spatial dimensions of shape and space must match")
 
-    bases = [
-            orthonormal_basis_for_space(b, s)
+    bases = [orthonormal_basis_for_space(b, s)
             for b, s in zip(space.bases, shape.bases)]
 
     return TensorProductBasis(

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1145,13 +1145,21 @@ class TensorProductBasis(Basis):
         return len(self._bases)
 
     @property
-    def mode_ids(self):
+    def _mode_index_tuples(self):
         from pytools import generate_nonnegative_integer_tuples_below as gnitb
         # ensure that these start numbering (0,0), (1,0), (i.e. x-axis first)
-        # FIXME (for review): should this change?
         return tuple(mid[::-1]
                      for mid in gnitb([len(b.functions)
                                        for b in self._bases[::-1]]))
+
+    @property
+    def mode_ids(self):
+        from pytools import generate_nonnegative_integer_tuples_below as gnitb
+        underlying_mode_ids = [basis.mode_ids for basis in self._bases]
+        return tuple(
+                tuple(umid[mid_index_i] for umid, mid_index_i in zip(
+                    underlying_mode_ids, mode_index_tuple))
+                for mode_index_tuple in self._mode_index_tuples)
 
     @property
     def functions(self):
@@ -1161,7 +1169,7 @@ class TensorProductBasis(Basis):
                     for ibasis, mid_i in enumerate(mid)
                     ]),
                     dims_per_function=self._dims_per_basis)
-                for mid in self.mode_ids)
+                for mid in self._mode_index_tuples)
 
     @property
     def gradients(self):
@@ -1179,7 +1187,7 @@ class TensorProductBasis(Basis):
                     for deriv_indicator_vec in wandering_element(self._nbases)
                     ]),
                     dims_per_function=self._dims_per_basis)
-                for mid in self.mode_ids)
+                for mid in self._mode_index_tuples)
 
 
 def _get_orth_weight(bases: Sequence[Basis]) -> Optional[float]:

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1112,21 +1112,12 @@ class TensorProductBasis(Basis):
             orth_weight: Optional[float],
             dims_per_basis: Optional[Tuple[int, ...]] = None) -> None:
         """
-        :param bases: a sequence of sequences (representing the basis) of
-            functions representing the approximation basis.
-        :param grad_bases: a sequence of sequences representing the
-            derivatives of *bases*.
+        :param bases: a sequence of 1D bases used to construct the tensor
+            product approximation basis.
         :param orth_weight: if *bases* forms an orthogonal basis, this should
             be the normalizing weight. If *None*, then the basis is assumed to
             not be orthogonal (this is not checked).
         """
-        # if len(bases) != len(grad_bases):
-        #     raise ValueError("'bases' and 'grad_bases' must have the same length")
-
-        # for i, (b, gb) in enumerate(zip(bases, grad_bases)):
-        #     if len(b) != len(gb):
-        #         raise ValueError(
-        #                 f"bases[{i}] and grad_bases[{i}] must have the same length")
 
         if dims_per_basis is None:
             dims_per_basis = (1,) * len(bases)

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -27,8 +27,8 @@ from warnings import warn
 from abc import ABC, abstractmethod
 from functools import singledispatch, partial
 from typing import (
-        Callable, Iterable, Optional, Sequence, TypeVar, Tuple, Union, Hashable,
-        TYPE_CHECKING)
+        Callable, Iterable, List, Optional, Sequence, TypeVar, Tuple, Union,
+        Hashable, TYPE_CHECKING)
 
 import numpy as np
 
@@ -1150,7 +1150,7 @@ class TensorProductBasis(Basis):
         return len(self._bases)
 
     @property
-    def _mode_index_tuples(self):
+    def _mode_index_tuples(self) -> Tuple[Tuple[int, ...], ...]:
         from pytools import generate_nonnegative_integer_tuples_below as gnitb
         # ensure that these start numbering (0,0), (1,0), (i.e. x-axis first)
         return tuple(mid[::-1]
@@ -1158,7 +1158,7 @@ class TensorProductBasis(Basis):
                                        for b in self._bases[::-1]]))
 
     @property
-    def mode_ids(self):
+    def mode_ids(self) -> Tuple[Hashable, ...]:
         underlying_mode_id_lists = [basis.mode_ids for basis in self._bases]
         is_all_singletons_with_int = [
                 all(isinstance(mid, tuple) and len(mid) == 1
@@ -1168,7 +1168,7 @@ class TensorProductBasis(Basis):
 
         def part_flat_tuple(iterable: Iterable[Tuple[bool, Hashable]]
                             ) -> Tuple[Hashable, ...]:
-            result = []
+            result: List[Hashable] = []
             for flatten, item in iterable:
                 if flatten:
                     assert isinstance(item, tuple)

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -1104,6 +1104,11 @@ def _monomial_basis_for_pn(space: PN, shape: Simplex):
 class TensorProductBasis(Basis):
     """Adapts multiple bases into a tensor product basis.
 
+    .. attribute:: bases
+
+        A sequence of :class:`Basis` objects that are being composed into
+        a tensor-product basis in a higher-dimensional space.
+
     .. automethod:: __init__
     """
 
@@ -1154,7 +1159,6 @@ class TensorProductBasis(Basis):
 
     @property
     def mode_ids(self):
-        from pytools import generate_nonnegative_integer_tuples_below as gnitb
         underlying_mode_ids = [basis.mode_ids for basis in self._bases]
         return tuple(
                 tuple(umid[mid_index_i] for umid, mid_index_i in zip(


### PR DESCRIPTION
Reduction in cost of tensor product operator evaluation comes from using the 1D bases used in the construction of the tensor product. This PR aims to make the 1D information accessible.