### PR TITLE
docs: rework to include attribute types

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,3 +20,5 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "pytools": ("https://documen.tician.de/pytools", None),
 }
+
+autodoc_member_order = "bysource"


### PR DESCRIPTION
This switches to inline attribute docs like
```
#: This is an attribute.
value: float
```
and uses `autoattribute` or just `:members:` to include them. Sphinx seems to pick this up a bit better and it shows up in the docs. For example for `Face`:

![Screenshot_20240307_101148](https://github.com/inducer/modepy/assets/777240/37c6ec28-2f83-4f65-92a0-510a2ae5faa5)

For comparison the current docs: https://documen.tician.de/modepy/shapes.html#modepy.Face