### PR TITLE
quadrature: add type annotations and improve docs

### DIFF
--- a/doc/quadrature.rst
+++ b/doc/quadrature.rst
@@ -14,12 +14,17 @@ Jacobi-Gauss quadrature in one dimension
 .. currentmodule:: modepy
 
 .. autoclass:: JacobiGaussQuadrature
+    :members:
+    :show-inheritance:
 
 .. autoclass:: LegendreGaussQuadrature
+    :show-inheritance:
 
 .. autoclass:: ChebyshevGaussQuadrature
+    :show-inheritance:
 
 .. autoclass:: GaussGegenbauerQuadrature
+    :show-inheritance:
 
 .. currentmodule:: modepy.quadrature.jacobi_gauss
 
@@ -35,8 +40,11 @@ Clenshaw-Curtis and Fejér quadrature in one dimension
 .. currentmodule:: modepy
 
 .. autoclass:: ClenshawCurtisQuadrature
+    :show-inheritance:
 
 .. autoclass:: FejerQuadrature
+    :members:
+    :show-inheritance:
 
 Quadratures on the simplex
 --------------------------
@@ -46,10 +54,16 @@ Quadratures on the simplex
 .. autoexception:: QuadratureRuleUnavailable
 
 .. autoclass:: GrundmannMoellerSimplexQuadrature
+    :members:
+    :show-inheritance:
 
 .. autoclass:: XiaoGimbutasSimplexQuadrature
+    :members:
+    :show-inheritance:
 
 .. autoclass:: VioreanuRokhlinSimplexQuadrature
+    :members:
+    :show-inheritance:
 
 
 Quadratures on the hypercube
@@ -58,8 +72,12 @@ Quadratures on the hypercube
 .. currentmodule:: modepy
 
 .. autoclass:: WitherdenVincentQuadrature
+    :members:
+    :show-inheritance:
 
 .. autoclass:: TensorProductQuadrature
+    :show-inheritance:
 .. autoclass:: LegendreGaussTensorProductQuadrature
+    :show-inheritance:
 
 .. vim: sw=4

--- a/modepy/matrices.py
+++ b/modepy/matrices.py
@@ -46,7 +46,7 @@ point interpolants:
 
 .. math::
 
-    V^T [\text{interpolation coefficents to point $x$}] = \phi_i(x),
+    V^T [\text{interpolation coefficients to point $x$}] = \phi_i(x),
 
 where :math:`(\phi_i)_i` is the basis of functions underlying :math:`V`.
 

--- a/modepy/modal_decay.py
+++ b/modepy/modal_decay.py
@@ -53,7 +53,7 @@ def simplex_interp_error_coefficient_estimator_matrix(
     yields the coeffiicients belonging to the basis functions of the *n_tail_orders*
     highest orders.
 
-    The 2-norm of the resulting coefficents can be used as an estimate of the
+    The 2-norm of the resulting coefficients can be used as an estimate of the
     interpolation error.
 
     .. versionadded:: 2018.1

--- a/modepy/quadrature/clenshaw_curtis.py
+++ b/modepy/quadrature/clenshaw_curtis.py
@@ -147,7 +147,7 @@ class FejerQuadrature(Quadrature):
 
     * Fejér quadrature of the second kind has *N - 1* points and uses only the
       interior extrema of the Chebyshev nodes, i.e. the true stationary points.
-      This rule is alsmost identical to Clenshaw-Curtis and can be nested.
+      This rule is almost identical to Clenshaw-Curtis and can be nested.
 
     Integrates on the interval :math:`(-1, 1)`. Implementation is based on
     [Waldvogel2003]_.

--- a/modepy/quadrature/jacobi_gauss.py
+++ b/modepy/quadrature/jacobi_gauss.py
@@ -20,6 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.linalg as la
@@ -39,14 +40,13 @@ class JacobiGaussQuadrature(Quadrature):
     where :math:`\alpha, \beta > -1`. The quadrature rule is exact
     up to degree :math:`2N + 1`.
 
-    Inherits from :class:`modepy.Quadrature`. See there for the interface
-    to obtain nodes and weights.
-
     .. automethod:: __init__
     """
 
-    def __init__(self, alpha, beta, N,                  # noqa: N803
-            backend=None, force_dim_axis=False):
+    def __init__(self,
+            alpha: float, beta: float, N: int,                  # noqa: N803
+            backend: Optional[str] = None,
+            force_dim_axis: bool = False) -> None:
         r"""
         :arg backend: Either ``"builtin"`` or ``"scipy"``. When the
             ``"builtin"`` backend is in use, there is an additional
@@ -83,8 +83,15 @@ class JacobiGaussQuadrature(Quadrature):
         exact_to = 2*N + 1
         super().__init__(x, w, exact_to=exact_to)
 
+        self.alpha: float = alpha
+        """Power of :math:`(1 - x)` term in Jacobi quadrature."""
+        self.beta: float = beta
+        """Power of :math:`(1 + x)` term in Jacobi quadrature."""
+
     @staticmethod
-    def compute_weights_and_nodes(N, alpha, beta):  # noqa: N803
+    def compute_weights_and_nodes(
+            N: int, alpha: float, beta: float,  # noqa: N803
+            ) -> Tuple[np.ndarray, np.ndarray]:
         """
         :arg N: order of the Gauss quadrature (the order of exactly
             integrated polynomials is :math:`2 N + 1`).
@@ -132,6 +139,7 @@ class JacobiGaussQuadrature(Quadrature):
                 return -(alpha**2 - beta**2) / ((2*n + apb) * (2*n + apb + 2))
 
         T = np.zeros((N + 1, N + 1))    # noqa: N806
+        current_a = 0.0
 
         for n in range(N + 1):
             T[n, n] = b(n)
@@ -165,8 +173,12 @@ class LegendreGaussQuadrature(JacobiGaussQuadrature):
     :math:`\alpha = \beta = 0`.
     """
 
-    def __init__(self, N, backend=None, force_dim_axis=False):  # noqa: N803
-        super().__init__(0, 0, N,
+    def __init__(self,
+                 N: int, backend:  # noqa: N803
+                 Optional[str] = None,
+                 force_dim_axis: bool = False) -> None:
+        super().__init__(
+                0, 0, N,
                 backend=backend, force_dim_axis=force_dim_axis)
 
 
@@ -181,7 +193,11 @@ class ChebyshevGaussQuadrature(JacobiGaussQuadrature):
     .. versionadded:: 2019.1
     """
 
-    def __init__(self, N, kind=1, backend=None, force_dim_axis=False):  # noqa: N803
+    def __init__(self,
+                 N: int,  # noqa: N803
+                 kind: int = 1,
+                 backend: Optional[str] = None,
+                 force_dim_axis: bool = False) -> None:
         if kind == 1:
             alpha = beta = -0.5
         elif kind == 2:
@@ -189,7 +205,8 @@ class ChebyshevGaussQuadrature(JacobiGaussQuadrature):
         else:
             raise ValueError(f"unsupported kind: '{kind}'")
 
-        super().__init__(alpha, beta, N,
+        super().__init__(
+                alpha, beta, N,
                 backend=backend, force_dim_axis=force_dim_axis)
 
 
@@ -200,13 +217,19 @@ class GaussGegenbauerQuadrature(JacobiGaussQuadrature):
     .. versionadded:: 2019.1
     """
 
-    def __init__(self, alpha, N, backend=None, force_dim_axis=False):  # noqa: N803
-        super().__init__(alpha, alpha, N,
+    def __init__(self,
+                 alpha: float, N: int,  # noqa: N803
+                 backend: Optional[str] = None,
+                 force_dim_axis: bool = False) -> None:
+        super().__init__(
+                alpha, alpha, N,
                 backend=backend, force_dim_axis=force_dim_axis)
 
 
-def jacobi_gauss_lobatto_nodes(alpha, beta, N,          # noqa: N803
-        backend=None, force_dim_axis=False):
+def jacobi_gauss_lobatto_nodes(
+        alpha: float, beta: float, N: int,          # noqa: N803
+        backend: Optional[str] = None,
+        force_dim_axis: bool = False) -> np.ndarray:
     """Compute the Gauss-Lobatto quadrature
     nodes corresponding to the :class:`~modepy.JacobiGaussQuadrature`
     with the same parameters.
@@ -233,8 +256,10 @@ def jacobi_gauss_lobatto_nodes(alpha, beta, N,          # noqa: N803
     return x
 
 
-def legendre_gauss_lobatto_nodes(N,                     # noqa: N803
-        backend=None, force_dim_axis=False):
+def legendre_gauss_lobatto_nodes(
+        N: int,                     # noqa: N803
+        backend: Optional[str] = None,
+        force_dim_axis: bool = False) -> np.ndarray:
     """Compute the Legendre-Gauss-Lobatto quadrature nodes.
 
     Exact to degree :math:`2N - 1`.

--- a/modepy/quadrature/vioreanu_rokhlin.py
+++ b/modepy/quadrature/vioreanu_rokhlin.py
@@ -29,42 +29,32 @@ from modepy.quadrature import Quadrature, QuadratureRuleUnavailable
 class VioreanuRokhlinSimplexQuadrature(Quadrature):
     """Simplicial quadratures with symmetric node sets and positive weights
     suitable for well-conditioned interpolation.
-    The integration domain is the unit simplex. (see :ref:`tri-coords`
-    and :ref:`tet-coords`)
 
-    Raises :exc:`modepy.QuadratureRuleUnavailable` if no quadrature rule for the
-    requested parameters is available.
-
-    Inherits from :class:`modepy.Quadrature`. See there for the interface
-    to obtain nodes and weights.
-
-    .. attribute:: exact_to
-
-        The total degree up to which the quadrature is exact.
-
-    When using these nodes, please acknowledge Zydrunas Gimbutas,
-    who generated them as follows:
+    The integration domain is the unit simplex (see :ref:`tri-coords`
+    and :ref:`tet-coords`). When using these nodes, please acknowledge Zydrunas
+    Gimbutas, who generated them as follows:
 
     * The 2D nodes are based on the interpolation node set derived
-      in the article
+      in the article [Vioreanu2011]_.
 
-          B. Vioreanu and V. Rokhlin, "Spectra of Multiplication Operators as a
-          Numerical Tool,"
-          `Yale CS Tech Report 1443
-          <http://www.cs.yale.edu/publications/techreports/tr1443.pdf>`_
-
-      Note that in Vioreanu's tables, only orders 5,6,9, and 12 are rotationally
+      Note that in Vioreanu's tables, only orders 5, 6, 9, and 12 are rotationally
       symmetric, which gives one extra order for integration and better
       interpolation conditioning. Also note that since the tables have been
       re-generated independently, the nodes and weights may be different.
 
     * The 3D nodes were derived from the :func:`modepy.warp_and_blend_nodes`.
 
-    * A tightening algorithm was then applied, as described in
+    * A tightening algorithm was then applied, as described in [Vioreanu2012]_.
 
-          B. Vioreanu, "Spectra of Multiplication Operators as a Numerical
-          Tool", Yale University, 2012.
-          `Dissertation <http://gradworks.umi.com/3525285.pdf>`_
+    .. [Vioreanu2011] B. Vioreanu and V. Rokhlin,
+        *Spectra of Multiplication Operators as a Numerical Tool*,
+        Yale CS Tech Report 1443.
+        `PDF <http://www.cs.yale.edu/publications/techreports/tr1443.pdf>`__
+
+    .. [Vioreanu2012] B. Vioreanu,
+        *Spectra of Multiplication Operators as a Numerical Tool*,
+        Yale University, 2012.
+        `PDF <http://gradworks.umi.com/3525285.pdf>`__
 
     .. versionadded :: 2013.3
 
@@ -74,17 +64,20 @@ class VioreanuRokhlinSimplexQuadrature(Quadrature):
 
     # FIXME: most other functionality in modepy uses 'dims, order' as the
     # argument order convention.
-    def __init__(self, order, dims):
+    def __init__(self, order: int, dims: int) -> None:
         """
         :arg order: The total degree to which the quadrature rule is exact
             for *interpolation*.
         :arg dims: The number of dimensions for the quadrature rule.
             2 for quadrature on triangles and 3 for tetrahedra.
+
+        :raises: :exc:`modepy.QuadratureRuleUnavailable` if no quadrature rule
+            for the requested parameters is available.
         """
 
         if dims == 2:
             from modepy.quadrature.vr_quad_data_tri import triangle_data as table
-            ref_volume = 2
+            ref_volume = 2.0
         elif dims == 3:
             from modepy.quadrature.vr_quad_data_tet import tetrahedron_data as table
             ref_volume = 4/3

--- a/modepy/quadrature/vioreanu_rokhlin.py
+++ b/modepy/quadrature/vioreanu_rokhlin.py
@@ -82,7 +82,7 @@ class VioreanuRokhlinSimplexQuadrature(Quadrature):
             from modepy.quadrature.vr_quad_data_tet import tetrahedron_data as table
             ref_volume = 4/3
         else:
-            raise QuadratureRuleUnavailable(f"invalid domension: '{dims}'")
+            raise QuadratureRuleUnavailable(f"invalid dimension: '{dims}'")
 
         from modepy.tools import EQUILATERAL_TO_UNIT_MAP
         e2u = EQUILATERAL_TO_UNIT_MAP[dims]

--- a/modepy/quadrature/witherden_vincent.py
+++ b/modepy/quadrature/witherden_vincent.py
@@ -25,16 +25,16 @@ from modepy.quadrature import Quadrature, QuadratureRuleUnavailable
 
 class WitherdenVincentQuadrature(Quadrature):
     """Symmetric quadrature rules with positive weights for rectangles and
-    hexahedra.
+    hexahedra from [Witherden2015]_.
 
     The integration domain is the unit hypercube :math:`[-1, 1]^d`, where :math:`d`
-    is the dimension. The quadrature rules are adapted from:
+    is the dimension.
 
-        F. D. Witherden, P. E. Vincent,
-        On the Identification of Symmetric Quadrature Rules for Finite
-        Element Methods,
-        Computers & Mathematics with Applications, Vol. 69, pp. 1232--1241, 2015,
-        `DOI <http://dx.doi.org/10.1016/j.camwa.2015.03.017>`_.
+    .. [Witherden2015] F. D. Witherden, P. E. Vincent,
+        *On the Identification of Symmetric Quadrature Rules for Finite
+        Element Methods*,
+        Computers & Mathematics with Applications, Vol. 69, pp. 1232--1241, 2015.
+        `DOI <http://dx.doi.org/10.1016/j.camwa.2015.03.017>`__
 
     .. versionadded: 2020.3
 
@@ -44,7 +44,7 @@ class WitherdenVincentQuadrature(Quadrature):
 
     # FIXME: most other functionality in modepy uses 'dims, order' as the
     # argument order convention.
-    def __init__(self, order, dims):
+    def __init__(self, order: int, dims: int) -> None:
         if dims == 2:
             from modepy.quadrature.witherden_vincent_quad_data import (
                 quad_data as table)

--- a/modepy/quadrature/witherden_vincent.py
+++ b/modepy/quadrature/witherden_vincent.py
@@ -52,7 +52,7 @@ class WitherdenVincentQuadrature(Quadrature):
             from modepy.quadrature.witherden_vincent_quad_data import (
                 hex_data as table)
         else:
-            raise QuadratureRuleUnavailable(f"invalid domension: '{dims}'")
+            raise QuadratureRuleUnavailable(f"invalid dimension: '{dims}'")
 
         try:
             rule = table[order]

--- a/modepy/quadrature/xg_quad_data.py
+++ b/modepy/quadrature/xg_quad_data.py
@@ -4,7 +4,7 @@
 import numpy
 
 
-triangle_table = {  # noqa
+triangle_table_orig = {
     1: {
         "points": [[-5.55111512312578e-17, 2.22044604925031e-16]],
         "weights": [1.73205080756888],
@@ -16406,11 +16406,11 @@ triangle_table = {  # noqa
 
 triangle_table = {
     order: {name: numpy.array(ary) for name, ary in rule.items()}
-    for order, rule in triangle_table.items()
+    for order, rule in triangle_table_orig.items()
 }
 
 
-tetrahedron_table = {  # noqa
+tetrahedron_table_orig = {
     1: {"points": [[0.0, 0.0, 0.0]], "weights": [0.942809041582063]},
     2: {
         "points": [
@@ -18537,5 +18537,5 @@ tetrahedron_table = {  # noqa
 
 tetrahedron_table = {
     order: {name: numpy.array(ary) for name, ary in rule.items()}
-    for order, rule in tetrahedron_table.items()
+    for order, rule in tetrahedron_table_orig.items()
 }

--- a/modepy/quadrature/xiao_gimbutas.py
+++ b/modepy/quadrature/xiao_gimbutas.py
@@ -25,28 +25,17 @@ from modepy.quadrature import Quadrature, QuadratureRuleUnavailable
 
 
 class XiaoGimbutasSimplexQuadrature(Quadrature):
-    """A (nearly) Gaussian simplicial quadrature with very few quadrature nodes,
-    available for low-to-moderate orders.
+    """A (nearly) Gaussian simplicial quadrature with very few quadrature nodes
+    from [Xiao2010]_.
 
-    Raises :exc:`modepy.QuadratureRuleUnavailable` if no quadrature rule for the
-    requested parameters is available.
+    This rule is available for low-to-moderate orders. The integration domain is
+    the unit simplex (see :ref:`tri-coords` and :ref:`tet-coords`).
 
-    The integration domain is the unit simplex. (see :ref:`tri-coords`
-    and :ref:`tet-coords`)
-
-    Inherits from :class:`modepy.Quadrature`. See there for the interface
-    to obtain nodes and weights.
-
-    .. attribute:: exact_to
-
-        The total degree up to which the quadrature is exact.
-
-    See
-
-        H. Xiao and Z. Gimbutas, "A numerical algorithm for the construction of
-        efficient quadrature rules in two and higher dimensions," Computers &
-        Mathematics with Applications, vol. 59, no. 2, pp. 663-676, 2010.
-        http://dx.doi.org/10.1016/j.camwa.2009.10.027
+    .. [Xiao2010] H. Xiao and Z. Gimbutas,
+        *A numerical algorithm for the construction of efficient quadrature rules
+        in two and higher dimensions*,
+        Computers & Mathematics with Applications, vol. 59, no. 2, pp. 663-676, 2010.
+        `DOI <http://dx.doi.org/10.1016/j.camwa.2009.10.027>`__
 
     .. automethod:: __init__
     .. automethod:: __call__
@@ -54,11 +43,13 @@ class XiaoGimbutasSimplexQuadrature(Quadrature):
 
     # FIXME: most other functionality in modepy uses 'dims, order' as the
     # argument order convention.
-    def __init__(self, order, dims):
+    def __init__(self, order: int, dims: int) -> None:
         """
-        :arg order: The total degree to which the quadrature rule is exact.
-        :arg dims: The number of dimensions for the quadrature rule.
+        :arg order: the total degree to which the quadrature rule is exact.
+        :arg dims: the number of dimensions for the quadrature rule.
             2 for quadrature on triangles and 3 for tetrahedra.
+        :raises: :exc:`modepy.QuadratureRuleUnavailable` if no quadrature rule
+            for therequested parameters is available.
         """
 
         if dims == 2:

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -528,7 +528,7 @@ def submesh_for_shape(
         shape: Shape, node_tuples: Sequence[Tuple[int, ...]]
         ) -> Sequence[Tuple[int, ...]]:
     """Return a list of tuples of indices into the node list that
-    generate a tesselation of the reference element.
+    generate a tessellation of the reference element.
 
     :arg node_tuples: A list of tuples *(i, j, ...)* of integers
         indicating node positions inside the unit element. The
@@ -583,7 +583,7 @@ def _submesh_for_simplex(shape: Simplex, node_tuples):
 
         # https://github.com/PyCQA/flake8-bugbear/issues/175
         for current in node_tuples:  # noqa: B007
-            # this is a tesselation of a square into two triangles.
+            # this is a tessellation of a square into two triangles.
             # subtriangles that fall outside of the master triangle are
             # simply not added.
 
@@ -611,7 +611,7 @@ def _submesh_for_simplex(shape: Simplex, node_tuples):
         result = []
         # https://github.com/PyCQA/flake8-bugbear/issues/175
         for current in node_tuples:  # noqa: B007
-            # this is a tesselation of a cube into six tets.
+            # this is a tessellation of a cube into six tets.
             # subtets that fall outside of the master tet are simply not added.
 
             # positively oriented

--- a/modepy/test/test_quadrature.py
+++ b/modepy/test/test_quadrature.py
@@ -48,7 +48,7 @@ def test_transformed_quadrature():
     sigma = 12
     tq = Transformed1DQuadrature(
             LegendreGaussQuadrature(20, force_dim_axis=True),
-            mu - 6*sigma, mu + 6*sigma)
+            left=mu - 6*sigma, right=mu + 6*sigma)
 
     result = tq(lambda x: gaussian_density(x, mu, sigma))
     assert abs(result - 1) < 1.0e-9

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -235,7 +235,7 @@ def barycentric_to_equilateral(bary):
 
 def simplex_submesh(node_tuples):
     """Return a list of tuples of indices into the node list that
-    generate a tesselation of the reference element.
+    generate a tessellation of the reference element.
 
     :arg node_tuples: A list of tuples *(i, j, ...)* of integers
         indicating node positions inside the unit element. The
@@ -252,7 +252,7 @@ submesh = MovedFunctionDeprecationWrapper(simplex_submesh)
 
 def hypercube_submesh(node_tuples):
     """Return a list of tuples of indices into the node list that
-    generate a tesselation of the reference element.
+    generate a tessellation of the reference element.
 
     :arg node_tuples: A list of tuples *(i, j, ...)* of integers
         indicating node positions inside the unit element. The

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -57,7 +57,7 @@ THE SOFTWARE.
 from functools import reduce
 from math import gamma  # noqa: F401
 from math import sqrt
-from typing import Protocol, Tuple, TypeVar, runtime_checkable
+from typing import Dict, Protocol, Tuple, TypeVar, runtime_checkable
 
 import numpy as np
 import numpy.linalg as la
@@ -158,7 +158,7 @@ class AffineMap:
 
 # {{{ simplex coordinate mapping
 
-EQUILATERAL_TO_UNIT_MAP = {
+EQUILATERAL_TO_UNIT_MAP: Dict[int, AffineMap] = {
         1: AffineMap([[1]], [0]),
         2: AffineMap([
             [1, -1/sqrt(3)],


### PR DESCRIPTION
The main contribution here is adding type annotation to the quadrature folder. It also updates the docs a bit in line with #73.

One refactor: in `clenshaw_curtis`, the constructor used to be `_make(n, kind)` and I broke them off into `_make_fejer1`, `_make_fejer2` and `_make_cc`. For context, `mypy` was complaining about overwriting some variables with different types and I got confused when moving things around, so I refactored it a bit. 