### PR TITLE
tests: use np.inf instead of np.Inf

### DIFF
--- a/modepy/test/test_nodes.py
+++ b/modepy/test/test_nodes.py
@@ -109,7 +109,7 @@ def test_tri_face_node_distribution():
 
     first_points = projected_face_points[0]
     for points in projected_face_points[1:]:
-        error = la.norm(points-first_points, np.Inf)
+        error = la.norm(points-first_points, np.inf)
         assert error < 1e-15
 
 # }}}


### PR DESCRIPTION
Found using `ruff check --select NPY201 .` as suggested in the numpy 2.0 migration guide.