### PR TITLE
Typing for `modepy.matrices`

### DIFF
--- a/modepy/__init__.py
+++ b/modepy/__init__.py
@@ -24,8 +24,9 @@ THE SOFTWARE.
 
 from modepy.matrices import (
     diff_matrix_permutation, differentiation_matrices, inverse_mass_matrix,
-    mass_matrix, modal_mass_matrix_for_face, nodal_mass_matrix_for_face,
-    nodal_quad_mass_matrix_for_face, resampling_matrix, vandermonde)
+    mass_matrix, modal_mass_matrix_for_face, multi_vandermonde,
+    nodal_mass_matrix_for_face, nodal_quad_mass_matrix_for_face, resampling_matrix,
+    vandermonde)
 from modepy.modes import (
     Basis, BasisNotOrthonormal, TensorProductBasis, basis_for_space, grad_jacobi,
     jacobi, monomial_basis_for_space, orthonormal_basis_for_space,
@@ -83,7 +84,8 @@ __all__ = [
         "edge_clustered_nodes_for_space", "equispaced_nodes_for_space",
         "random_nodes_for_shape",
 
-        "vandermonde", "resampling_matrix", "differentiation_matrices",
+        "vandermonde", "multi_vandermonde",
+        "resampling_matrix", "differentiation_matrices",
         "diff_matrix_permutation",
         "inverse_mass_matrix", "mass_matrix",
         "modal_mass_matrix_for_face", "nodal_mass_matrix_for_face",


### PR DESCRIPTION
- Add `multi_vandermonde` for gradient Vandermonde, deprecate using `vandermonde` for this.
- `mass_matrix`, `inverse_mass_matrix`: request `Basis`, deprecate list of functions, add guard on orthogonality.