### PR TITLE
pyproject: hack around to make editable install work

### DIFF
--- a/modepy/version.py
+++ b/modepy/version.py
@@ -1,2 +1,9 @@
-VERSION = (2024, 1)
-VERSION_TEXT = ".".join(str(i) for i in VERSION)
+import re
+from importlib import metadata
+
+
+VERSION_TEXT = metadata.version("modepy")
+_match = re.match("^([0-9.]+)([a-z0-9]*?)$", VERSION_TEXT)
+assert _match is not None
+VERSION_STATUS = _match.group(2)
+VERSION = tuple(int(nr) for nr in _match.group(1).split("."))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ include = [
     "modepy*",
 ]
 
+[tool.setuptools.package-dir]
+# https://github.com/Infleqtion/client-superstaq/pull/715
+"" = "."
+
 [tool.setuptools.package-data]
 modepy = [
     "py.typed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,8 @@ modepy = [
 
 [tool.ruff]
 target-version = "py38"
-line-length = 85
-
 preview = true
+
 [tool.ruff.lint]
 extend-select = [
     "B",   # flake8-bugbear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ preview = true
 extend-select = [
     "B",   # flake8-bugbear
     "C",   # flake8-comprehensions
-    "D",   # pydocstyle
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # flake8-isort
@@ -91,7 +90,6 @@ extend-select = [
 ]
 extend-ignore = [
     "C90",  # McCabe complexity
-    "D",    # pydocstyle
     "E221", # multiple spaces before operator
     "E226", # missing whitespace around arithmetic operator
     "E241", # multiple spaces after comma


### PR DESCRIPTION
Switching to `pyproject.toml` completely with `setuptools` seems to have broken editable installs a bit for `mypy` (and possibly others): https://github.com/python/mypy/issues/13392.

From reading through that, there seem to be a few options to hack around it:
1. Use the current workaround with setting `package-dir`. Not sure why this works, but it seems to work and is used by others too.
2. Use `pip install --config-settings editable_mode=strict --editable .`. This seems to work, but it's easy to forget to add options to `pip install`.
3. Switch to a `src-layout`: https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/. Not sure what `setuptools` is doing differently in that case, but it seems to pick up the typing correctly with no other changes..
4. Switch to another build system. Hatchling (https://hatch.pypa.io/latest/) is small and seems to do the right thing by default for editable installs.

I mostly went with 1 because it's very non-intrusive, but it doesn't seem documented as a workaround for editable installs, so the behavior might change..