### PR TITLE
Support reshaping 1d tensor products

### DIFF
--- a/modepy/test/test_tools.py
+++ b/modepy/test/test_tools.py
@@ -499,7 +499,7 @@ def test_tensor_product_shapes():
 
 # {{{ tensor product reshape
 
-@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("dim", [1, 2, 3])
 def test_tensor_product_reshape(dim):
     interval = mp.Simplex(1)
     shape = mp.TensorProductShape((interval,) * dim)

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -475,7 +475,7 @@ ReshapeableT = TypeVar("ReshapeableT", bound=Reshapeable)
 
 
 def reshape_array_for_tensor_product_space(
-        space: TensorProductSpace, ary: ReshapeableT, axis=-1) -> ReshapeableT:
+        space: TensorProductSpace, ary: ReshapeableT, axis: int = -1) -> ReshapeableT:
     """Return a reshaped view of *ary* that exposes the tensor product nature
     of the space. Axis number *axis* of *ary* must index coefficients
     corresponding to a tensor-product-structured basis (e.g. modal or nodal
@@ -489,13 +489,21 @@ def reshape_array_for_tensor_product_space(
         function along a given dimension will be represented by variation
         of array entries along the corresponding array axis.
     """
+
+    ndim = len(ary.shape)
     if axis < 0:
-        axis += len(ary.shape)
-    if not (0 <= axis < len(ary.shape)):
-        raise ValueError("invalid axis specified")
+        axis += ndim
+
+    if not (0 <= axis < ndim):
+        raise ValueError(f"Invalid axis specified: {axis} not in 0..{ndim}")
+
     if ary.shape[axis] != space.space_dim:
-        raise ValueError(f"array's axis {axis} must have length "
+        raise ValueError(f"The input array's axis {axis} must have length "
                 f"{space.space_dim}, found {ary.shape[axis]} instead")
+
+    if space.spatial_dim == 1:
+        return ary
+
     return ary.reshape(
             (ary.shape[:axis]
                 + tuple(s.space_dim for s in space.bases)

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -477,13 +477,15 @@ ReshapeableT = TypeVar("ReshapeableT", bound=Reshapeable)
 def reshape_array_for_tensor_product_space(
         space: TensorProductSpace, ary: ReshapeableT, axis: int = -1) -> ReshapeableT:
     """Return a reshaped view of *ary* that exposes the tensor product nature
-    of the space. Axis number *axis* of *ary* must index coefficients
-    corresponding to a tensor-product-structured basis (e.g. modal or nodal
-    coefficients).
+    of the *space*.
 
-    :arg ary: an array with last dimension having a length matching the
+    :arg ary: an array with *axis* dimension having a length matching the
         :attr:`~modepy.FunctionSpace.space_dim` of *space*.
-    :arg result: *ary* reshaped with axis number *axis* replaced by
+    :arg axis: an integer that must index a dimension of *ary* with coefficients
+        corresponding to a tensor-product-structured basis (e.g. modal or nodal
+        coefficients).
+
+    :returns: *ary* reshaped with axis number *axis* replaced by
         a tuple of dimensions matching the dimensions of the spaces
         making up the tensor product. Variation of the represented
         function along a given dimension will be represented by variation


### PR DESCRIPTION
Any reason this wasn't allowed? It mostly broke when trying to access `space.bases`, but a 1D tensor product space was just a `PN` on a `Simplex(1)`.

Not sure if just returning the array is sufficient, but the tests seem to pass.