### PR TITLE
Fix reshaping/unreshaping for tensor product spaces in 1D

### DIFF
--- a/modepy/test/test_tools.py
+++ b/modepy/test/test_tools.py
@@ -555,7 +555,7 @@ def test_tensor_product_reshape(dim):
 
 # {{{ test_tensor_product_vdm_dim_by_dim
 
-@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("dim", [1, 2, 3])
 def test_tensor_product_vdm_dim_by_dim(dim):
     """Apply tensor product Vandermonde one dimension at a time, check that the
     result matches what's obtained via the whole-space Vandermonde.
@@ -580,8 +580,15 @@ def test_tensor_product_vdm_dim_by_dim(dim):
     x_r = reshape_array_for_tensor_product_space(space, x)
     vdm_dimbydim_x_r = x_r
 
+    if dim == 1:
+        space_bases = (space,)
+        shape_bases = (shape,)
+    else:
+        space_bases = space.bases
+        shape_bases = shape.bases
+
     for i, (subspace, subshape) in enumerate(
-                            zip(space.bases, shape.bases, strict=True)):
+                            zip(space_bases, shape_bases, strict=True)):
         subnodes = mp.edge_clustered_nodes_for_space(subspace, subshape)
         subbasis = mp.basis_for_space(subspace, subshape)
         subvdm = mp.vandermonde(subbasis.functions, subnodes)

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -491,6 +491,8 @@ def reshape_array_for_tensor_product_space(
         function along a given dimension will be represented by variation
         of array entries along the corresponding array axis.
     """
+    if space.spatial_dim == 1:
+        return ary
 
     ndim = len(ary.shape)
     if axis < 0:
@@ -518,6 +520,8 @@ def unreshape_array_for_tensor_product_space(
     """Undoes the effect of :func:`reshape_array_for_tensor_product_space`,
     given the same *space* and *axis*.
     """
+    if space.spatial_dim == 1:
+        return ary
 
     n_tp_axes = len(space.bases)
     naxes = len(ary.shape) - n_tp_axes + 1

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -70,7 +70,7 @@ import numpy.linalg as la
 from pytools import MovedFunctionDeprecationWrapper, memoize_method
 
 import modepy.shapes as shp
-from modepy.spaces import TensorProductSpace
+from modepy.spaces import FunctionSpace, TensorProductSpace
 
 
 class Monomial:
@@ -475,7 +475,7 @@ ReshapeableT = TypeVar("ReshapeableT", bound=Reshapeable)
 
 
 def reshape_array_for_tensor_product_space(
-        space: TensorProductSpace, ary: ReshapeableT, axis: int = -1) -> ReshapeableT:
+        space: FunctionSpace, ary: ReshapeableT, axis: int = -1) -> ReshapeableT:
     """Return a reshaped view of *ary* that exposes the tensor product nature
     of the *space*.
 
@@ -491,7 +491,7 @@ def reshape_array_for_tensor_product_space(
         function along a given dimension will be represented by variation
         of array entries along the corresponding array axis.
     """
-    if space.spatial_dim == 1:
+    if not isinstance(space, TensorProductSpace):
         return ary
 
     ndim = len(ary.shape)
@@ -505,9 +505,6 @@ def reshape_array_for_tensor_product_space(
         raise ValueError(f"The input array's axis {axis} must have length "
                 f"{space.space_dim}, found {ary.shape[axis]} instead")
 
-    if space.spatial_dim == 1:
-        return ary
-
     return ary.reshape(
             (ary.shape[:axis]
                 + tuple(s.space_dim for s in space.bases)
@@ -516,11 +513,11 @@ def reshape_array_for_tensor_product_space(
 
 
 def unreshape_array_for_tensor_product_space(
-        space: TensorProductSpace, ary: ReshapeableT, axis=-1) -> ReshapeableT:
+        space: FunctionSpace, ary: ReshapeableT, axis=-1) -> ReshapeableT:
     """Undoes the effect of :func:`reshape_array_for_tensor_product_space`,
     given the same *space* and *axis*.
     """
-    if space.spatial_dim == 1:
+    if not isinstance(space, TensorProductSpace):
         return ary
 
     n_tp_axes = len(space.bases)


### PR DESCRIPTION
`unreshape_array_for_tensor_product_space` currently fails for 1D. It checks `space.bases`, but in 1D this is `PN`, which doesn't have a `bases` attribute. This leads to a bunch of unnecessary checks on spatial dimension before attempting to reshape in an upstream package to guarantee we don't fail.

`reshape_array_for_tensor_product_space` works in the 1D case, but does some unnecessary work since the input array and returned array will be the same.

If the spatial dimension of the space is 1, we should just return the array in both cases since there's nothing to do. This PR updates corresponding functions to do just that. Also updates one of the tests to test for `unreshape_array_for_tensor_product_space` to test the 1D case.