### PR TITLE
Enable and fix PGH ruff rules

### DIFF
--- a/modepy/nodes.py
+++ b/modepy/nodes.py
@@ -124,7 +124,7 @@ def warp_factor(n, output_nodes, scaled=True):
     from modepy.modes import jacobi
 
     basis = [partial(jacobi, 0, 0, n) for n in range(n + 1)]
-    Veq = vandermonde(basis, equi_nodes)  # noqa
+    Veq = vandermonde(basis, equi_nodes)  # noqa: N806
 
     # create interpolator from equi_nodes to output_nodes
     eq_to_out = la.solve(Veq.T, vandermonde(basis, output_nodes).T).T

--- a/modepy/test/test_quadrature.py
+++ b/modepy/test/test_quadrature.py
@@ -59,7 +59,7 @@ def test_transformed_quadrature():
 
 
 try:
-    import scipy  # noqa
+    import scipy  # noqa: F401
 except ImportError:
     BACKENDS = [None, "builtin"]
 else:

--- a/modepy/test/test_tools.py
+++ b/modepy/test/test_tools.py
@@ -77,7 +77,7 @@ def constant(x):
 
 @pytest.mark.parametrize(("case_name", "test_func", "dims", "n", "expected_expn"), [
     ("jump-1d", partial(jump, 0), 1, 10, -1),
-    ("kink-1d", partial(kink, 0), 1, 10, -1.7),  # Slightly off from -2 (same in paper)  # noqa
+    ("kink-1d", partial(kink, 0), 1, 10, -1.7),  # Slightly off from -2 (same in paper)
     ("c1-1d", partial(c1, 0), 1, 10, -3),
 
     # Offset 1D tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,12 @@ extend-select = [
     "N",   # pep8-naming
     "NPY", # numpy
     "Q",   # flake8-quotes
+    "PGH", # pygrep-hooks
+    "RUF", # ruff
+    "SIM", # flake8-simplify
+    "UP",  # pyupgrade
     "W",   # pycodestyle
-    "RUF",
-    "UP",
-    "SIM",
 ]
-
 extend-ignore = [
     "C90",  # McCabe complexity
     "E221", # multiple spaces before operator


### PR DESCRIPTION
Found a set of rules that complain about bare `# noqa` and `# type: ignore` which seemed useful :grin: 

https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh