### PR TITLE
Port plot-basis to modern modepy

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -84,22 +84,6 @@
         ],
         "./examples/plot-basis.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 0,
@@ -110,32 +94,32 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 35,
+                    "startColumn": 14,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAny",
+                "code": "reportGeneralTypeIssues",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 48,
+                    "startColumn": 4,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 22,
+                    "startColumn": 5,
+                    "endColumn": 6,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 8,
-                    "endColumn": 28,
+                    "endColumn": 9,
                     "lineCount": 1
                 }
             },
@@ -144,6 +128,14 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -167,7 +159,7 @@
                 "code": "reportUnknownArgumentType",
                 "range": {
                     "startColumn": 22,
-                    "endColumn": 44,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -238,8 +230,16 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
+                    "startColumn": 6,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
                     "startColumn": 5,
-                    "endColumn": 15,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -295,7 +295,7 @@
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 0,
-                    "endColumn": 10,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
             },
@@ -303,7 +303,7 @@
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 0,
-                    "endColumn": 7,
+                    "endColumn": 8,
                     "lineCount": 1
                 }
             }

--- a/examples/plot-basis.py
+++ b/examples/plot-basis.py
@@ -1,42 +1,35 @@
 from __future__ import annotations
 
-import matplotlib.pyplot as pt
+import matplotlib.pyplot as plt
 import numpy as np
 
-from pytools import (
-    generate_nonnegative_integer_tuples_summing_to_at_most as gnitstam,
-)
+import modepy as mp
 
-from modepy.modes import simplex_onb
-from modepy.tools import submesh
 
+# prepare basis vectors
+shape = mp.Simplex(2)
+space = mp.PN(2, 3)
+basis = mp.orthonormal_basis_for_space(space, shape)
 
 # prepare plot and eval nodes on triangle
-dims = 2
-node_n = 40
-node_tuples = list(gnitstam(node_n, dims))
-plot_nodes = np.array(node_tuples, dtype=np.float64) / node_n
-eval_nodes = 2*(plot_nodes - 0.5).T
+plot_space = mp.PN(2, 32)
+node_tuples = mp.node_tuples_for_space(plot_space)
+eval_nodes = mp.equispaced_nodes_for_space(plot_space, shape)
+plot_nodes = (eval_nodes.T + 1) / 2
 
 # get triangle submesh
-tri_subtriangles = np.array(submesh(node_tuples))
+tri_subtriangles = np.array(mp.submesh_for_shape(shape, node_tuples))
 
-# evaluate each basis function, build global tri mesh
+# evaluate each basis function, build global triangle mesh
 node_count = 0
 all_nodes = []
 all_triangles = []
 all_values = []
 
-p = 3
 stretch_factor = 1.5
 
-for (i, j), basis_func in zip(
-        gnitstam(p, dims),
-        simplex_onb(dims, p),
-        strict=True,
-        ):
-
-    all_nodes.append([*plot_nodes, stretch_factor * i, stretch_factor * j])
+for (i, j), basis_func in zip(basis.mode_ids, basis.functions, strict=True):
+    all_nodes.append(plot_nodes + [stretch_factor * i, stretch_factor * j])  # noqa: RUF005
     all_triangles.append(tri_subtriangles + node_count)
     all_values.append(basis_func(eval_nodes))
     node_count += len(plot_nodes)
@@ -46,9 +39,11 @@ all_triangles = np.vstack(all_triangles)
 all_values = np.hstack(all_values)
 
 # plot
-x, y = np.mgrid[-1:p*stretch_factor + 1:20j, -1:p*stretch_factor + 1:20j]
+x, y = np.mgrid[-1:space.order*stretch_factor + 1:20j,
+                -1:space.order*stretch_factor + 1:20j]
 
-ax = pt.subplot(1, 1, 1, projection="3d")
+fig = plt.figure(figsize=(10, 5), dpi=300)
+ax = fig.add_subplot(1, 1, 1, projection="3d")
 ax.view_init(azim=-150, elev=25, roll=0)
 
 ax.plot_wireframe(x, y, 0 * x, color="k", alpha=0.15, lw=0.5)
@@ -60,9 +55,8 @@ ax.plot_trisurf(all_nodes[:, 0], all_nodes[:, 1], 0.25 * all_values,
 
 ax.set_axis_off()
 ax.set_aspect("equal")
-pt.savefig("plot-basis-pkdo-2d.png",
-           transparent=True,
-           dpi=300,
-           pad_inches=0,
-           bbox_inches="tight")
-pt.show()
+plt.savefig("plot-basis-pkdo-2d.png",
+            transparent=True,
+            pad_inches=0,
+            bbox_inches="tight")
+plt.show()

--- a/examples/plot-quadrature-nodes.py
+++ b/examples/plot-quadrature-nodes.py
@@ -125,7 +125,9 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--name", choices=["cc", "gm", "js", "vr", "wv", "xg"])
+    parser.add_argument("--name",
+                        choices=["cc", "gm", "js", "vr", "wv", "xg"],
+                        default="vr")
     parser.add_argument("--order", type=int, default=4)
     parser.add_argument("--dims", type=int, default=2)
     parser.add_argument("--show", action="store_true")


### PR DESCRIPTION
The `plot-basis.py` example was broken when `simplex_onb` was removed in #81. This updates the example to use the new API.