### PR TITLE
Add link to nudg github repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ Its roots closely followed the approach taken in the book
     *Nodal Discontinuous Galerkin Methods: Algorithms, Analysis, and Applications*
     (1st ed.).
     `doi:10.1007/978-0-387-72067-8 <https://doi.org/10.1007/978-0-387-72067-8>`__.
+    `(source code) <https://github.com/tcew/nodal-dg>`__
 
 but much has been added beyond that basic functionality.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,6 +29,7 @@ functionality.
     *Nodal Discontinuous Galerkin Methods: Algorithms, Analysis, and Applications*
     (1st ed.).
     `doi:10.1007/978-0-387-72067-8 <https://doi.org/10.1007/978-0-387-72067-8>`__.
+    `(source code) <https://github.com/tcew/nodal-dg>`__
 
 Example
 -------


### PR DESCRIPTION
This adds back the links to the `nodal-dg` repo. From what I can tell `nudg.org` redirects to Github from the `http` site, but not the `https` version, so better to link directly to this.

xref #137 