### PR TITLE
Add type annotations to tests

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -1650,62 +1650,6 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -4118,14 +4062,6 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 20,
@@ -4962,70 +4898,6 @@
         ],
         "./modepy/test/test_modes.py": [
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 8,
@@ -5044,88 +4916,8 @@
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 44,
+                    "startColumn": 25,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -5134,406 +4926,6 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 5,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 61,
                     "lineCount": 1
                 }
             },
@@ -5554,26 +4946,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -5602,38 +4978,6 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 16,
@@ -5642,7 +4986,7 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 30,
                     "endColumn": 41,
@@ -5674,223 +5018,7 @@
                 }
             },
             {
-                "code": "reportImplicitOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 19,
                     "endColumn": 27,
@@ -5906,34 +5034,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 59,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
@@ -5954,103 +5058,7 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 19,
                     "endColumn": 27,
@@ -6066,26 +5074,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 59,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 19,
                     "lineCount": 1
                 }
             },
@@ -6098,31 +5090,7 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 35,
@@ -6150,46 +5118,6 @@
                 "range": {
                     "startColumn": 31,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -6228,30 +5156,6 @@
         ],
         "./modepy/test/test_nodes.py": [
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 11,
@@ -6270,56 +5174,8 @@
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
                     "startColumn": 15,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 21,
                     "lineCount": 1
                 }
             },
@@ -6340,118 +5196,6 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 12,
@@ -6460,7 +5204,7 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 21,
                     "endColumn": 58,
@@ -6468,74 +5212,10 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
                     "lineCount": 1
                 }
             },
@@ -6550,16 +5230,8 @@
             {
                 "code": "reportAny",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 20,
-                    "lineCount": 2
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 31,
+                    "startColumn": 15,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -6572,26 +5244,10 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
+                "code": "reportAny",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 52,
+                    "startColumn": 23,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -6761,30 +5417,6 @@
                     "startColumn": 12,
                     "endColumn": 21,
                     "lineCount": 3
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 46,
-                    "lineCount": 1
                 }
             }
         ],
@@ -7152,63 +5784,7 @@
         ],
         "./modepy/test/test_quadrature.py": [
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 15,
                     "endColumn": 9,
@@ -7216,7 +5792,7 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 21,
                     "endColumn": 64,
@@ -7226,24 +5802,8 @@
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 25,
+                    "startColumn": 18,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -7264,98 +5824,26 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 15,
-                    "endColumn": 25,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 31,
+                    "startColumn": 27,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 19,
+                    "startColumn": 44,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
@@ -7368,86 +5856,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 12,
@@ -7472,42 +5880,26 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 19,
                     "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -7536,54 +5928,6 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 12,
@@ -7592,18 +5936,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 37,
-                    "endColumn": 40,
+                    "startColumn": 28,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 18,
-                    "endColumn": 52,
+                    "startColumn": 35,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -7691,15 +6043,15 @@
                 "code": "reportUnknownArgumentType",
                 "range": {
                     "startColumn": 14,
-                    "endColumn": 48,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 47,
+                    "startColumn": 32,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -7712,26 +6064,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 15,
                     "lineCount": 1
                 }
             },
@@ -7754,181 +6090,13 @@
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
                     "startColumn": 20,
                     "endColumn": 42,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
+                "code": "reportReturnType",
                 "range": {
                     "startColumn": 15,
                     "endColumn": 20,
@@ -7936,71 +6104,23 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 16,
+                    "startColumn": 28,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 22,
+                    "startColumn": 35,
                     "endColumn": 38,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 42,
@@ -8008,55 +6128,7 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 41,
@@ -8114,466 +6186,10 @@
         ],
         "./modepy/test/test_tools.py": [
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 6,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 83,
-                    "endColumn": 5,
-                    "lineCount": 17
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
                 "range": {
                     "startColumn": 18,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 5,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
@@ -8594,30 +6210,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 4,
@@ -8626,162 +6218,18 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 5,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 29,
+                    "startColumn": 18,
                     "endColumn": 38,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
+                "code": "reportAny",
                 "range": {
                     "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 32,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -8794,30 +6242,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 4,
@@ -8826,26 +6250,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 4,
                     "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -8862,62 +6270,6 @@
                 "range": {
                     "startColumn": 52,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
                     "lineCount": 1
                 }
             },
@@ -8966,46 +6318,6 @@
                 "range": {
                     "startColumn": 53,
                     "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -9066,66 +6378,10 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 19,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -9134,54 +6390,6 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 60,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 60,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -9218,314 +6426,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 60,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 71,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportPrivateUsage",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
@@ -9634,82 +6538,10 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 4,
                     "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -9738,106 +6570,18 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
+                "code": "reportAny",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 69,
+                    "startColumn": 45,
                     "endColumn": 72,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownVariableType",
+                "code": "reportAny",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 56,
+                    "startColumn": 53,
+                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -9882,14 +6626,6 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 16,
@@ -9914,62 +6650,6 @@
                 }
             },
             {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 7,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 8,
@@ -9978,106 +6658,10 @@
                 }
             },
             {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 4,
                     "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -10473,6 +7057,22 @@
                     "startColumn": 8,
                     "endColumn": 16,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 22,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 22,
+                    "lineCount": 5
                 }
             }
         ]

--- a/modepy/modes.py
+++ b/modepy/modes.py
@@ -231,7 +231,7 @@ def grad_jacobi(alpha: float, beta: float, n: int, x: RealValueT) -> RealValueT:
         return math.sqrt(n*(n+alpha+beta+1)) * jacobi(alpha+1, beta+1, n-1, x)
 
 
-def binom(x, y):
+def binom(x: float, y: float) -> float:
     # FIXME This may overflow quickly.
     # mpmath has clever 'gammaprod' pole handling in case that's ever needed:
     # https://github.com/mpmath/mpmath/blob/75a2ed37c4f2c576a9d01d360ee4c94ead57c7ff/mpmath/functions/factorials.py#L61-L65

--- a/modepy/shapes.py
+++ b/modepy/shapes.py
@@ -420,7 +420,7 @@ class _SimplexFace(Simplex, Face):
 
 
 @unit_vertices_for_shape.register(Simplex)
-def unit_vertices_for_simplex(shape: Simplex):
+def unit_vertices_for_simplex(shape: Simplex) -> ArrayF:
     result = np.empty((shape.dim, shape.dim+1), np.float64)
     result.fill(-1)
 
@@ -489,7 +489,7 @@ class Hypercube(TensorProductShape):
     def __init__(self, dim: int) -> None:
         super().__init__((Simplex(1),) * dim)
 
-    def __getnewargs__(self):
+    def __getnewargs__(self) -> tuple[Any, ...]:
         # NOTE: ensures Hypercube is picklable
         return (self.dim,)
 

--- a/modepy/test/test_modes.py
+++ b/modepy/test/test_modes.py
@@ -25,10 +25,12 @@ THE SOFTWARE.
 
 
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.linalg as la
 import pytest
+from typing_extensions import override
 
 from pymbolic.mapper.evaluator import EvaluationMapper
 from pymbolic.mapper.stringifier import (
@@ -39,6 +41,11 @@ from pymbolic.mapper.stringifier import (
 import modepy as mp
 from modepy.typing import ArrayF
 
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pymbolic.primitives import If
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +60,7 @@ logger = logging.getLogger(__name__)
     (5, 0),
     (3, 4)
     ])
-def test_scaled_jacobi(alpha, beta):
+def test_scaled_jacobi(alpha: float, beta: float) -> None:
     from modepy.modes import binom, scaled_jacobi as jacobi
 
     for n in range(10):
@@ -76,7 +83,7 @@ def test_scaled_jacobi(alpha, beta):
     (5, 0, 3e-13),
     (3, 4, 1e-14)
     ])
-def test_orthonormality_jacobi_1d(alpha, beta, ebound):
+def test_orthonormality_jacobi_1d(alpha: float, beta: float, ebound: float) -> None:
     """Verify that the Jacobi polymials are orthogonal in 1D."""
     from modepy.quadrature.jacobi_gauss import JacobiGaussQuadrature
 
@@ -85,20 +92,16 @@ def test_orthonormality_jacobi_1d(alpha, beta, ebound):
 
     from functools import partial
     jac_f = [partial(mp.jacobi, alpha, beta, n) for n in range(max_n)]
-    maxerr = 0
 
     for i, fi in enumerate(jac_f):
         for j, fj in enumerate(jac_f):
             result = quad(lambda x: fi(x)*fj(x))  # noqa: B023
             true_result = 1.0 if i == j else 0.0
 
-            err = abs(result-true_result)
-            maxerr = np.maximum(maxerr, err)
-            if abs(result - true_result) > ebound:
-                logger.error("[FAILED] (%g, %g): (%d, %d) error %.5e",
-                        alpha, beta, i, j, abs(result - true_result))
-
-            assert abs(result-true_result) < ebound
+            err = np.abs(result-true_result)
+            assert err < ebound, (
+                f"[FAILED] ({alpha}, {beta}): ({i}, {j}) error {err:.5e}"
+            )
 
 # }}}
 
@@ -110,7 +113,7 @@ def test_orthonormality_jacobi_1d(alpha, beta, ebound):
     mp.Hypercube(3),
     ])
 @pytest.mark.parametrize("order", [1, 2, 4, 6])
-def test_basis_size_against_space_dim(shape, order):
+def test_basis_size_against_space_dim(shape: mp.Shape, order: int) -> None:
     space = mp.space_for_shape(shape, order)
     for basis in [
                 mp.basis_for_space(space, shape),
@@ -136,7 +139,7 @@ def test_basis_size_against_space_dim(shape, order):
     mp.Hypercube(2),
     mp.Hypercube(3),
     ])
-def test_basis_orthogonality(shape, order, ebound):
+def test_basis_orthogonality(order: int, ebound: float, shape: mp.Shape) -> None:
     """Test orthogonality of ONBs using cubature."""
 
     qspace = mp.space_for_shape(shape, 2*order)
@@ -148,13 +151,14 @@ def test_basis_orthogonality(shape, order, ebound):
         for j, g in enumerate(basis.functions):
             true_result = 1 if i == j else 0
             result = cub(lambda x: f(x)*g(x))  # noqa: B023
+
             err = abs(result-true_result)
-            logger.info("error %.5e max %.5e", err, maxerr)
             maxerr = np.maximum(maxerr, err)
-            if err > ebound:
-                logger.info("bound exceeded at order %d for (f_{%d}, f_{%d}): %.5e",
-                        order, i, j, err)
-            assert err < ebound
+            logger.info("error %.5e max %.5e", err, maxerr)
+
+            assert err < ebound, (
+                f"bound exceeded at order {order} for (f_{i}, f_{j}): {err:.5e}"
+            )
 
     logger.info("order %d max error %.5e", order, maxerr)
 
@@ -163,7 +167,10 @@ def test_basis_orthogonality(shape, order, ebound):
 
 # {{{ test_basis_grad
 
-def get_inhomogeneous_tensor_prod_basis(space, shape):
+def get_inhomogeneous_tensor_prod_basis(
+        space: mp.FunctionSpace,
+        shape: mp.Shape
+    ) -> mp.Basis:
     if space.spatial_dim == 1:
         return mp.basis_for_space(space, shape)
 
@@ -185,7 +192,12 @@ def get_inhomogeneous_tensor_prod_basis(space, shape):
 
     (mp.Hypercube, get_inhomogeneous_tensor_prod_basis),
     ])
-def test_basis_grad(dim, shape_cls, order, basis_getter):
+def test_basis_grad(
+        dim: int,
+        order: int,
+        shape_cls: type[mp.Shape],
+        basis_getter: Callable[[mp.FunctionSpace, mp.Shape], mp.Basis]
+    ) -> None:
     """Do a simplistic FD-style check on the gradients of the basis."""
 
     h = 1.0e-4
@@ -242,7 +254,8 @@ class MyStringifyMapper(CSESplittingStringifyMapperMixin[[]], StringifyMapper[[]
 
 
 class MyEvaluationMapper(EvaluationMapper[ArrayF]):
-    def map_if(self, expr):
+    @override
+    def map_if(self, expr: If, /) -> ArrayF:
         return np.where(self.rec(expr.condition),
                 self.rec(expr.then), self.rec(expr.else_))
 
@@ -261,7 +274,11 @@ class MyEvaluationMapper(EvaluationMapper[ArrayF]):
     (mp.orthonormal_basis_for_space),
     (mp.monomial_basis_for_space),
     ])
-def test_symbolic_basis(shape, order, basis_getter):
+def test_symbolic_basis(
+        shape: mp.Shape,
+        order: int,
+        basis_getter: Callable[[mp.FunctionSpace, mp.Shape], mp.Basis]
+    ) -> None:
     basis = basis_getter(mp.space_for_shape(shape, order), shape)
     sym_basis = [mp.symbolicize_function(f, shape.dim) for f in basis.functions]
 
@@ -337,7 +354,7 @@ def test_symbolic_basis(shape, order, basis_getter):
 # {{{ test_modal_coeffs_by_projection
 
 @pytest.mark.parametrize("dim", [2, 3])
-def test_modal_coeffs_by_projection(dim):
+def test_modal_coeffs_by_projection(dim: int) -> None:
     shape = mp.Simplex(dim)
     space = mp.space_for_shape(shape, order=5)
     basis = mp.orthonormal_basis_for_space(space, shape)
@@ -360,7 +377,7 @@ def test_modal_coeffs_by_projection(dim):
 # }}}
 
 
-def test_tp_0d():
+def test_tp_0d() -> None:
     basis = mp.TensorProductBasis([])
     nodes = np.zeros((0, 15))
     for f in basis.functions:

--- a/modepy/test/test_nodes.py
+++ b/modepy/test/test_nodes.py
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.linalg as la
@@ -32,10 +33,14 @@ import modepy.nodes as nd
 import modepy.shapes as shp
 
 
+if TYPE_CHECKING:
+    from modepy.typing import ArrayF
+
+
 # {{{ test_barycentric_coordinate_map
 
 @pytest.mark.parametrize("dims", [1, 2, 3])
-def test_barycentric_coordinate_map(dims):
+def test_barycentric_coordinate_map(dims: int) -> None:
     n = 100
     from modepy.tools import (
         barycentric_to_equilateral,
@@ -62,12 +67,12 @@ def test_barycentric_coordinate_map(dims):
 
 # {{{ test_warp
 
-def test_warp():
+def test_warp() -> None:
     """Check some assumptions on the node warp factor calculator"""
     n = 17
     from functools import partial
 
-    def wfc(x):
+    def wfc(x: float) -> float:
         return nd.warp_factor(n, np.array([x]), scaled=False)[0]
 
     assert abs(wfc(-1)) < 1e-12
@@ -83,7 +88,7 @@ def test_warp():
 
 # {{{ test_tri_face_node_distribution
 
-def test_tri_face_node_distribution():
+def test_tri_face_node_distribution() -> None:
     """Test whether the nodes on the faces of the triangle are distributed
     according to the same proportions on each face.
 
@@ -105,7 +110,7 @@ def test_tri_face_node_distribution():
             [i for i, nt in enumerate(node_tuples) if sum(nt) == n]
             ]
 
-    projected_face_points = []
+    projected_face_points: list[ArrayF] = []
     for face_i in faces:
         start = unodes[:, face_i[0]]
         end = unodes[:, face_i[-1]]
@@ -126,7 +131,7 @@ def test_tri_face_node_distribution():
 
 @pytest.mark.parametrize("dims", [1, 2, 3])
 @pytest.mark.parametrize("n", [1, 3, 6])
-def test_simplex_nodes(dims, n):
+def test_simplex_nodes(dims: int, n: int) -> None:
     """Verify basic assumptions on simplex interpolation nodes"""
 
     eps = 1e-10
@@ -140,7 +145,7 @@ def test_simplex_nodes(dims, n):
 
 # {{{ test_affine_map
 
-def test_affine_map():
+def test_affine_map() -> None:
     """Check that our cheapo geometry-targeted linear algebra actually works."""
     from modepy.tools import AffineMap
 
@@ -162,9 +167,9 @@ def test_affine_map():
 # {{{ test_tensor_product_nodes
 
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
-def test_tensor_product_nodes(dim):
+def test_tensor_product_nodes(dim: int) -> None:
     nnodes = 10
-    nodes_1d = np.arange(nnodes)
+    nodes_1d = np.arange(nnodes, dtype=np.float64)
     nodes = nd.tensor_product_nodes(dim, nodes_1d)
 
     assert np.allclose(
@@ -177,10 +182,10 @@ def test_tensor_product_nodes(dim):
 # {{{ test_nonhomogeneous_tensor_product_nodes
 
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
-def test_nonhomogeneous_tensor_product_nodes(dim):
+def test_nonhomogeneous_tensor_product_nodes(dim: int) -> None:
     nnodes = (3, 7, 5, 4)[:dim]
     nodes = nd.tensor_product_nodes([
-        np.arange(n) for n in nnodes
+        np.arange(n, dtype=np.float64) for n in nnodes
         ])
 
     assert np.allclose(
@@ -195,13 +200,12 @@ def test_nonhomogeneous_tensor_product_nodes(dim):
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
 @pytest.mark.parametrize("shape_cls", [shp.Hypercube, shp.Simplex])
-def test_order0_nodes(dim, shape_cls):
+def test_order0_nodes(dim: int, shape_cls: type[shp.Shape]) -> None:
     shape = shape_cls(dim)
     import modepy as mp
     space = mp.space_for_shape(shape, order=0)
 
-    centroid = (np.mean(mp.unit_vertices_for_shape(shape), axis=1)
-            .reshape(-1, 1))
+    centroid = np.mean(mp.unit_vertices_for_shape(shape), axis=1).reshape(-1, 1)
     nodes = mp.equispaced_nodes_for_space(space, shape)
     assert not np.isnan(nodes).any()
     assert np.allclose(centroid, nodes)
@@ -216,7 +220,7 @@ def test_order0_nodes(dim, shape_cls):
 # {{{ test_tensor_product_shape_nodes
 
 @pytest.mark.parametrize("shape", ["square", "cube", "squared_cube", "prism"])
-def test_tensor_product_shape_nodes(shape, visualize=False):
+def test_tensor_product_shape_nodes(shape: str, visualize: bool = False) -> None:
     order = (5, 3, 4)
 
     if shape == "square":
@@ -257,12 +261,12 @@ def test_tensor_product_shape_nodes(shape, visualize=False):
 
 # {{{ test_tensor_product_nodes_vs_tuples
 
-def test_tensor_product_nodes_vs_tuples():
+def test_tensor_product_nodes_vs_tuples() -> None:
     import modepy as mp
     shapes = [
-            (shp.Hypercube(2), (3, 5)),
-            (shp.Hypercube(3), (3, 5, 4)),
-            ]
+        (shp.Hypercube(2), (3, 5)),
+        (shp.Hypercube(3), (3, 5, 4)),
+    ]
 
     for shape, order in shapes:
         space = mp.space_for_shape(shape, order)
@@ -277,7 +281,7 @@ def test_tensor_product_nodes_vs_tuples():
 
 # {{{ test_random_nodes_for_tensor_product
 
-def test_random_nodes_for_tensor_product():
+def test_random_nodes_for_tensor_product() -> None:
     import modepy as mp
     shape = mp.TensorProductShape((mp.Simplex(1), mp.Simplex(2)))
 
@@ -294,7 +298,7 @@ def test_random_nodes_for_tensor_product():
 
 # {{{ test_tp_0d
 
-def test_tp_0d():
+def test_tp_0d() -> None:
     import modepy as mp
     shape = mp.Hypercube(0)
     space = mp.QN(0, 5)

--- a/modepy/test/test_quad_construction.py
+++ b/modepy/test/test_quad_construction.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from modepy.typing import NodalFunction
 
 
+# {{{ test_quad_finder_lincomb
+
 def test_quad_finder_lincomb() -> None:
     basis = constr.adapt_2d_integrands_to_complex_arg(
         mp.monomial_basis_for_space(
@@ -72,6 +74,10 @@ def test_quad_finder_lincomb() -> None:
     for test_f, ref_f in zip(b2, b2_ref, strict=True):
         assert la.norm(test_f(base_quad.nodes) - ref_f(base_quad.nodes), 2) < 1e-13
 
+# }}}
+
+
+# {{{ test_orthogonalize_basis
 
 def test_orthogonalize_basis() -> None:
     orig_basis = mp.monomial_basis_for_space(mp.PN(2, order=7), mp.Simplex(2))
@@ -94,6 +100,10 @@ def test_orthogonalize_basis() -> None:
     eye = constr._mass_matrix(integrate, onb)
     assert la.norm(eye - np.eye(len(onb))) < 2e-12
 
+# }}}
+
+
+# {{{ test_guess_nodes_vr
 
 def test_guess_nodes_vr() -> None:
     order = 7
@@ -131,6 +141,10 @@ def test_guess_nodes_vr() -> None:
         plt.gca().set_aspect("equal")
         plt.show()
 
+# }}}
+
+
+# {{{ test_undetermined_coeffs
 
 def test_undetermined_coeffs() -> None:
     order = 7
@@ -159,6 +173,10 @@ def test_undetermined_coeffs() -> None:
         print(order, repr(f), err)
         assert err < 2e-15, (err, comb, i_f, ref)
 
+# }}}
+
+
+# {{{ test_quad_residual_derivatives
 
 def test_quad_residual_derivatives() -> None:
     order = 7
@@ -241,6 +259,10 @@ def test_quad_residual_derivatives() -> None:
     print(eoc_rec)
     assert eoc_rec.order_estimate() >= 0.95
 
+# }}}
+
+
+# {{{ test_quad_gauss_newton
 
 def test_quad_gauss_newton() -> None:
     order = 7
@@ -287,3 +309,16 @@ def test_quad_gauss_newton() -> None:
         resid_norm = la.norm(qrj.residual)
 
     assert resid_norm < 1e-14
+
+# }}}
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: fdm=marker

--- a/modepy/test/test_quadrature.py
+++ b/modepy/test/test_quadrature.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.linalg as la
@@ -33,13 +34,18 @@ import pytest
 import modepy as mp
 
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from modepy.typing import ArrayF
+
 logger = logging.getLogger(__name__)
 
 
-def test_transformed_quadrature():
+def test_transformed_quadrature() -> None:
     """Test 1D quadrature on arbitrary intervals"""
 
-    def gaussian_density(x, mu, sigma):
+    def gaussian_density(x: ArrayF, mu: float, sigma: float) -> ArrayF:
         return (
             1 / (sigma * np.sqrt(2*np.pi))
             * np.exp(-np.sum((x-mu)**2, axis=0) / (2 * sigma**2))
@@ -55,7 +61,7 @@ def test_transformed_quadrature():
             left=mu - 6*sigma, right=mu + 6*sigma)
 
     result = tq(lambda x: gaussian_density(x, mu, sigma))
-    assert abs(result - 1) < 1.0e-9
+    assert np.abs(result - 1.0) < 1.0e-9
 
 
 try:
@@ -67,21 +73,21 @@ else:
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-@pytest.mark.parametrize("quad_type", [
+@pytest.mark.parametrize("quad_cls", [
                              mp.LegendreGaussQuadrature,
                              mp.LegendreGaussLobattoQuadrature,
                          ])
-def test_gauss_quadrature(backend, quad_type):
+def test_gauss_quadrature(backend: str, quad_cls: type[mp.Quadrature]) -> None:
     for s in range(9 + 1):
-        if quad_type == mp.LegendreGaussLobattoQuadrature and s == 0:
+        if quad_cls is mp.LegendreGaussLobattoQuadrature and s == 0:
             # no one-node Lobatto rule
             continue
 
-        quad = quad_type(s, backend=backend, force_dim_axis=True)
+        quad = quad_cls(s, backend=backend, force_dim_axis=True)
 
         assert quad.nodes.shape[1] == s+1
         for deg in range(quad.exact_to + 1):
-            def f(x):
+            def f(x: ArrayF) -> ArrayF:
                 return np.sum(x**deg, axis=0)  # noqa: B023
 
             i_f = quad(f)
@@ -97,7 +103,7 @@ def test_clenshaw_curtis_quadrature() -> None:
         quad = ClenshawCurtisQuadrature(s, force_dim_axis=True)
         assert quad.nodes.shape[1] == s+1
         for deg in range(quad.exact_to + 1):
-            def f(x):
+            def f(x: ArrayF) -> ArrayF:
                 return x**deg  # noqa: B023
 
             i_f = quad(f)
@@ -114,7 +120,7 @@ def test_fejer_quadrature(kind: int) -> None:
         s = deg * 3
         quad = FejerQuadrature(s, kind, force_dim_axis=True)
 
-        def f(x):
+        def f(x: ArrayF) -> ArrayF:
             return x**deg  # noqa: B023
 
         i_f = quad(f)
@@ -123,14 +129,16 @@ def test_fejer_quadrature(kind: int) -> None:
         assert err < 2.0e-15, (s, deg, err, i_f, i_f_true)
 
 
-@pytest.mark.parametrize(("quad_class", "highest_order"), [
+@pytest.mark.parametrize(("quad_cls", "highest_order"), [
     (mp.XiaoGimbutasSimplexQuadrature, None),
     (mp.JaskowiecSukumarQuadrature, None),
     (mp.VioreanuRokhlinSimplexQuadrature, None),
     (mp.GrundmannMoellerSimplexQuadrature, 3),
     ])
 @pytest.mark.parametrize("dim", [2, 3])
-def test_simplex_quadrature(quad_class, highest_order, dim) -> None:
+def test_simplex_quadrature(quad_cls: type[mp.Quadrature],
+                            highest_order: int | None,
+                            dim: int) -> None:
     """Check that quadratures on simplices works as advertised"""
     from pytools import (
         generate_nonnegative_integer_tuples_summing_to_at_most as gnitstam,
@@ -141,15 +149,15 @@ def test_simplex_quadrature(quad_class, highest_order, dim) -> None:
     order = 1
     while True:
         try:
-            quad = quad_class(order, dim)
+            quad = quad_cls(order, dim)
         except mp.QuadratureRuleUnavailable:
-            print(("UNAVAILABLE", quad_class, order))
+            print(("UNAVAILABLE", quad_cls, order))
             break
 
-        if isinstance(quad_class, mp.VioreanuRokhlinSimplexQuadrature):
+        if isinstance(quad_cls, mp.VioreanuRokhlinSimplexQuadrature):
             assert (quad.weights > 0).all()
 
-        if isinstance(quad_class, mp.JaskowiecSukumarQuadrature):
+        if isinstance(quad_cls, mp.JaskowiecSukumarQuadrature):
             assert (quad.weights > 0).all()
 
         if 0:
@@ -157,7 +165,7 @@ def test_simplex_quadrature(quad_class, highest_order, dim) -> None:
             pt.plot(quad.nodes[0], quad.nodes[1])
             pt.show()
 
-        print((quad_class, order, quad.exact_to))
+        print((quad_cls, order, quad.exact_to))
         for comb in gnitstam(quad.exact_to, dim):
             f = Monomial(comb)
             i_f = quad(f)
@@ -172,21 +180,23 @@ def test_simplex_quadrature(quad_class, highest_order, dim) -> None:
 
 
 @pytest.mark.parametrize("dim", [2, 3])
-@pytest.mark.parametrize(("quad_class", "max_order"), [
+@pytest.mark.parametrize(("quad_cls", "max_order"), [
     (mp.WitherdenVincentQuadrature, np.inf),
     (mp.LegendreGaussTensorProductQuadrature, 6),
     ])
-def test_hypercube_quadrature(dim, quad_class, max_order):
+def test_hypercube_quadrature(dim: int,
+                              quad_cls: type[mp.Quadrature],
+                              max_order: float) -> None:
     from pytools import (
         generate_nonnegative_integer_tuples_summing_to_at_most as gnitstam,
     )
 
     from modepy.tools import Monomial
 
-    def _check_monomial(quad, comb):
+    def _check_monomial(quad: mp.Quadrature, comb: Sequence[int]) -> float:
         f = Monomial(comb)
         int_approx = quad(f)
-        int_exact = 2**dim * f.hypercube_integral()
+        int_exact = 2.0**dim * f.hypercube_integral()
 
         error = abs(int_approx - int_exact) / abs(int_exact)
         logger.info("%s: %.5e %.5e / rel error %.5e",
@@ -197,7 +207,7 @@ def test_hypercube_quadrature(dim, quad_class, max_order):
     order = 1
     while order < max_order:
         try:
-            quad = quad_class(order, dim)
+            quad = quad_cls(order, dim)
         except mp.QuadratureRuleUnavailable:
             logger.info("UNAVAILABLE at order %d", order)
             break
@@ -205,7 +215,7 @@ def test_hypercube_quadrature(dim, quad_class, max_order):
         assert np.all(quad.weights > 0)
 
         logger.info("quadrature: %s %d %d",
-                quad_class.__name__.lower(), order, quad.exact_to)
+                quad_cls.__name__.lower(), order, quad.exact_to)
         for comb in gnitstam(quad.exact_to, dim):
             assert _check_monomial(quad, comb) < 5.0e-15
 

--- a/modepy/test/test_tools.py
+++ b/modepy/test/test_tools.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 
 import logging
 from functools import partial
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import numpy.linalg as la
@@ -33,41 +34,46 @@ import pytest
 import modepy as mp
 
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from modepy.typing import ArrayF
+
 logger = logging.getLogger(__name__)
 
 
 # {{{ modal decay test functions
 
-def jump(where, x):
+def jump(where: float, x: ArrayF) -> ArrayF:
     result = np.empty_like(x)
     result[x >= where] = 1
     result[x < where] = 0
     return result
 
 
-def smooth_jump(where, x):
+def smooth_jump(where: float, x: ArrayF) -> ArrayF:
     return np.arctan(100*(x-where))/(0.5*np.pi)
 
 
-def kink(where, x):
+def kink(where: float, x: ArrayF) -> ArrayF:
     result = np.empty_like(x)
     result[x >= where] = x[x >= where]
     result[x < where] = 0
     return result
 
 
-def c1(where, x):
+def c1(where: float, x: ArrayF) -> ArrayF:
     result = np.empty_like(x)
     result[x >= where] = x[x >= where]**2
     result[x < where] = 0
     return result
 
 
-def sample_polynomial(x):
+def sample_polynomial(x: ArrayF) -> ArrayF:
     return 3*x**2 + 5*x + 3
 
 
-def constant(x):
+def constant(x: ArrayF) -> ArrayF:
     return 5+0*x
 
 # }}}
@@ -92,7 +98,11 @@ def constant(x):
     ("kink-2d", partial(kink, 0), 2, 15, -1.6),
     ("c1-2d", partial(c1, -0.1), 2, 15, -2.3),
     ])
-def test_modal_decay(case_name, test_func, dims, n, expected_expn):
+def test_modal_decay(case_name: str,
+                     test_func: Callable[[ArrayF], ArrayF],
+                     dims: int,
+                     n: int,
+                     expected_expn: float) -> None:
     space = mp.PN(dims, n)
     nodes = mp.warp_and_blend_nodes(dims, n)
     basis = mp.orthonormal_basis_for_space(space, mp.Simplex(dims))
@@ -110,7 +120,7 @@ def test_modal_decay(case_name, test_func, dims, n, expected_expn):
     expn = expn[0]
 
     print(f"{case_name}: computed: {expn:g}, expected: {expected_expn:g}")
-    assert abs(expn-expected_expn) < 0.1
+    assert np.abs(expn - expected_expn) < 0.1
 
 
 @pytest.mark.parametrize(("case_name", "test_func", "dims", "n"), [
@@ -122,8 +132,11 @@ def test_modal_decay(case_name, test_func, dims, n, expected_expn):
     ("poly-2d", sample_polynomial, 2, 5),
     ("const-2d", constant, 2, 5),
     ])
-def test_residual_estimation(case_name, test_func, dims, n):
-    def estimate_resid(inner_n):
+def test_residual_estimation(case_name: str,
+                             test_func: Callable[[ArrayF], ArrayF],
+                             dims: int,
+                             n: int) -> None:
+    def estimate_resid(inner_n: int) -> ArrayF:
         nodes = mp.warp_and_blend_nodes(dims, inner_n)
         basis = mp.orthonormal_basis_for_space(
                 mp.PN(dims, inner_n), mp.Simplex(dims))
@@ -148,7 +161,10 @@ def test_residual_estimation(case_name, test_func, dims, n):
 
 @pytest.mark.parametrize("dims", [1, 2, 3])
 @pytest.mark.parametrize("shape_cls", [mp.Simplex, mp.Hypercube])
-def test_resampling_matrix(dims, shape_cls, ncoarse=5, nfine=10):
+def test_resampling_matrix(dims: int,
+                           shape_cls: type[mp.Shape],
+                           ncoarse: int = 5,
+                           nfine: int = 10) -> None:
     shape = shape_cls(dims)
 
     coarse_space = mp.space_for_shape(shape, ncoarse)
@@ -181,7 +197,7 @@ def test_resampling_matrix(dims, shape_cls, ncoarse=5, nfine=10):
     mp.TensorProductSpace((mp.QN(1, 3), mp.QN(1, 5), mp.QN(1, 2))),
     mp.TensorProductSpace((mp.QN(2, 3), mp.QN(1, 2))),
     ])
-def test_non_homogeneous_tensor_product_resampling(space_nh):
+def test_non_homogeneous_tensor_product_resampling(space_nh: mp.FunctionSpace) -> None:
     shape = mp.Hypercube(space_nh.spatial_dim)
     orders_h = 5
 
@@ -224,7 +240,9 @@ def test_non_homogeneous_tensor_product_resampling(space_nh):
 
 # {{{ test_diff_matrix
 
-def _test_diff_matrix(space, shape, rtol=2.0e-4):
+def _test_diff_matrix(space: mp.FunctionSpace,
+                      shape: mp.Shape,
+                      rtol: float = 2.0e-4) -> None:
     nodes = mp.edge_clustered_nodes_for_space(space, shape)
     basis = mp.basis_for_space(space, shape)
 
@@ -239,7 +257,6 @@ def _test_diff_matrix(space, shape, rtol=2.0e-4):
     for i in range(shape.dim):
         error = la.norm(df_dx[i] - df_dx_num[i]) / la.norm(df_dx[i])
         logger.info("error: %.5e", error)
-        print(error)
 
         assert error < rtol, error
 
@@ -249,7 +266,9 @@ def _test_diff_matrix(space, shape, rtol=2.0e-4):
     (mp.Simplex, 5),
     (mp.Hypercube, 5),
     (mp.Hypercube, (6, 7, 5))])
-def test_diff_matrix(dims, shape_cls, order):
+def test_diff_matrix(dims: int,
+                     shape_cls: type[mp.Shape],
+                     order: int | tuple[int, ...]) -> None:
     if isinstance(order, tuple):
         order = order[dims] if dims == 1 else order[:dims]
 
@@ -258,7 +277,7 @@ def test_diff_matrix(dims, shape_cls, order):
     _test_diff_matrix(space, shape)
 
 
-def test_nonhomogeneous_tensor_product_diff_matrix():
+def test_nonhomogeneous_tensor_product_diff_matrix() -> None:
     shape = mp.Hypercube(3)
     space = mp.TensorProductSpace((mp.QN(2, 5), mp.QN(1, 5)))
 
@@ -266,7 +285,7 @@ def test_nonhomogeneous_tensor_product_diff_matrix():
 
 
 @pytest.mark.parametrize("dims", [2, 3])
-def test_diff_matrix_permutation(dims):
+def test_diff_matrix_permutation(dims: int) -> None:
     order = 5
     space = mp.PN(dims, order)
 
@@ -295,7 +314,10 @@ def test_diff_matrix_permutation(dims):
 
 @pytest.mark.parametrize("dims", [2, 3])
 @pytest.mark.parametrize("shape_cls", [mp.Simplex, mp.Hypercube])
-def test_nodal_quadrature_bilinear_form_matrix_for_face(dims, shape_cls, order=3):
+def test_nodal_quadrature_bilinear_form_matrix_for_face(
+        dims: int,
+        shape_cls: type[mp.Shape],
+        order: int = 3) -> None:
     vol_shape = shape_cls(dims)
     vol_space = mp.space_for_shape(vol_shape, order)
 
@@ -356,7 +378,11 @@ def test_nodal_quadrature_bilinear_form_matrix_for_face(dims, shape_cls, order=3
 @pytest.mark.parametrize("dims", [1, 2])
 @pytest.mark.parametrize("order", [3, 5, 8])
 @pytest.mark.parametrize("shape_cls", [mp.Simplex, mp.Hypercube])
-def test_estimate_lebesgue_constant(dims, order, shape_cls, visualize=False):
+def test_estimate_lebesgue_constant(
+        dims: int,
+        order: int,
+        shape_cls: type[mp.Shape],
+        visualize: bool = False) -> None:
     shape = shape_cls(dims)
     space = mp.space_for_shape(shape, order)
 
@@ -401,7 +427,7 @@ def test_estimate_lebesgue_constant(dims, order, shape_cls, visualize=False):
 # {{{ test_hypercube_submesh
 
 @pytest.mark.parametrize("dims", [2, 3, 4])
-def test_hypercube_submesh(dims, order=3):
+def test_hypercube_submesh(dims: int, order: int = 3) -> None:
     shape = mp.Hypercube(dims)
     space = mp.space_for_shape(shape, order)
 
@@ -431,7 +457,7 @@ def test_hypercube_submesh(dims, order=3):
     mp.Hypercube(2),
     mp.Hypercube(3),
     ])
-def test_normals(shape):
+def test_normals(shape: mp.Shape) -> None:
     vol_vertices = mp.unit_vertices_for_shape(shape)
     vol_centroid = np.mean(vol_vertices, axis=1)
 
@@ -453,7 +479,7 @@ def test_normals(shape):
 
 # {{{ test_tensor_product_shapes
 
-def test_tensor_product_shapes():
+def test_tensor_product_shapes() -> None:
     # shape, dim, nvertices, nfaces
     shapes = [
             (mp.Hypercube(1), 1, 2, 2),
@@ -485,7 +511,7 @@ def test_tensor_product_shapes():
 # {{{ tensor product reshape
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
-def test_tensor_product_reshape(dim):
+def test_tensor_product_reshape(dim: int) -> None:
     interval = mp.Simplex(1)
     shape = mp.TensorProductShape((interval,) * dim)
     space = mp.TensorProductSpace(tuple(mp.PN(1, 4+i) for i in range(dim)))
@@ -516,7 +542,7 @@ def test_tensor_product_reshape(dim):
                 nodes_r[0][nid]
 
             for j in range(dim):
-                varies_along_axis_j = np.diff(nodes_r[i], axis=j).any()
+                varies_along_axis_j = np.any(np.diff(nodes_r[i], axis=j))
                 assert varies_along_axis_j == (j == i)
 
             f_ax = np.exp(nodes[i])
@@ -541,7 +567,7 @@ def test_tensor_product_reshape(dim):
 # {{{ test_tensor_product_vdm_dim_by_dim
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
-def test_tensor_product_vdm_dim_by_dim(dim):
+def test_tensor_product_vdm_dim_by_dim(dim: int) -> None:
     """Apply tensor product Vandermonde one dimension at a time, check that the
     result matches what's obtained via the whole-space Vandermonde.
     """
@@ -597,7 +623,7 @@ def test_tensor_product_vdm_dim_by_dim(dim):
 
 @pytest.mark.parametrize("dims", [1, 2, 3])
 @pytest.mark.parametrize("shape_cls", [mp.Simplex, mp.Hypercube])
-def test_shape_pickling(dims, shape_cls):
+def test_shape_pickling(dims: int, shape_cls: type[mp.Shape]) -> None:
     import pickle
 
     shape = shape_cls(dims)
@@ -608,20 +634,20 @@ def test_shape_pickling(dims, shape_cls):
     assert shape == reloaded_shape
 
     pkl2 = pickle.dumps(tp_space)
-    reloaded_tp_space = pickle.loads(pkl2)
+    reloaded_tp_space = cast("mp.FunctionSpace", pickle.loads(pkl2))
     assert tp_space.spatial_dim == reloaded_tp_space.spatial_dim
     assert tp_space.space_dim == reloaded_tp_space.space_dim
 
 # }}}
 
 
-def test_inf():
+def test_inf() -> None:
     from modepy.quadrature import _Inf  # pyright: ignore[reportPrivateUsage]
 
     with pytest.raises(TypeError):
         - _Inf()  # pyright: ignore[reportOperatorIssue, reportUnusedExpression]
 
-    def agree(x: bool, y: bool):
+    def agree(x: bool, y: bool) -> bool:
         if x is NotImplemented or y is NotImplemented:
             return True
         else:

--- a/modepy/tools.py
+++ b/modepy/tools.py
@@ -56,11 +56,11 @@ THE SOFTWARE.
 """
 
 import math
-from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, runtime_checkable
 
 import numpy as np
 import numpy.linalg as la
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from pytools import memoize_method
 
@@ -414,8 +414,10 @@ class Reshapeable(Protocol):
     def shape(self) -> tuple[int, ...]: ...
 
     def reshape(
-            self, *newshape: tuple[int, ...], order: str
-            ) -> Self:
+            self,
+            shape: tuple[int, ...], /, *,
+            order: Literal["A", "C", "F"] | None = "C"
+        ) -> Reshapeable:
         ...
 
 


### PR DESCRIPTION
This mostly adds more type annotations to the tests.

The only interesting change is the update to `Reshapeable`. I changed it to at least accept `ArrayF` now. From a quick grep, this seems to only be used in `meshmode` (and this change makes the cast unnecessary):

https://github.com/inducer/meshmode/blob/6bbb682185aadd4f299f851cdfe5805fdb4c8f1a/meshmode/discretization/poly_element.py#L567-L569